### PR TITLE
using previous travis-ci image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+group: deprecated-2017Q2
 language: cpp
 cache: ccache
 sudo: required


### PR DESCRIPTION
using previous travis-ci image to temporally avoid a code format problem.