### PR TITLE
fix caffe2paddle by adding dims to convolution bias parameter proto

### DIFF
--- a/image_classification/caffe2paddle/caffe2paddle.py
+++ b/image_classification/caffe2paddle/caffe2paddle.py
@@ -72,6 +72,10 @@ class ModelConverter(object):
                 file_name = "_%s.w%s" % (name, str(i))
             param_conf = ParameterConfig()
             param_conf.name = file_name
+            dims = list(data.shape)
+            if len(dims) == 1:
+                dims.insert(1, 1)
+                param_conf.dims.extend(dims)
             param_conf.size = reduce(lambda a, b: a * b, data.shape)
             self.params[file_name] = (param_conf, data.flatten())
 


### PR DESCRIPTION
Add dims to convolution bias parameter proto, fix the shape discrepancy setting parameter values by`parameter.set`. Since the `Inference.__init__` doesn't call `parameter.set`, the bug didn't emerge when doing inference.