### PR TITLE
update installation of libsndfile, add unitest of soundfile

### DIFF
--- a/.travis/unittest.sh
+++ b/.travis/unittest.sh
@@ -10,6 +10,7 @@ unittest(){
     cd $1 > /dev/null
     if [ -f "setup.sh" ]; then
         sh setup.sh
+        export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
     fi
     if [ $? != 0 ]; then
         exit 1

--- a/deep_speech_2/.gitignore
+++ b/deep_speech_2/.gitignore
@@ -1,0 +1,1 @@
+thirdparty

--- a/deep_speech_2/.gitignore
+++ b/deep_speech_2/.gitignore
@@ -1,1 +1,0 @@
-thirdparty

--- a/deep_speech_2/README.md
+++ b/deep_speech_2/README.md
@@ -8,9 +8,6 @@ Please replace `$PADDLE_INSTALL_DIR` with your own paddle installation directory
 sh setup.sh
 export LD_LIBRARY_PATH=$PADDLE_INSTALL_DIR/Paddle/third_party/install/warpctc/lib:$LD_LIBRARY_PATH
 ```
-
-For some machines, we also need to install libsndfile1. Details to be added.
-
 ## Usage
 
 ### Preparing Data

--- a/deep_speech_2/requirements.txt
+++ b/deep_speech_2/requirements.txt
@@ -1,5 +1,6 @@
 wget==3.2
 scipy==0.13.1
 resampy==0.1.5
-https://github.com/kpu/kenlm/archive/master.zip
+SoundFile==0.9.0.post1
 python_speech_features
+https://github.com/kpu/kenlm/archive/master.zip

--- a/deep_speech_2/setup.sh
+++ b/deep_speech_2/setup.sh
@@ -9,7 +9,9 @@ if [ $? != 0 ]; then
     exit 1
 fi
 
-# install package Soundfile
+# install package libsndfile
+DIR="$( cd "$(dirname "$0")" ; pwd -P )"
+mkdir thirdparty
 curl -O "http://www.mega-nerd.com/libsndfile/files/libsndfile-1.0.28.tar.gz"
 if [ $? != 0 ]; then
     echo "Download libsndfile-1.0.28.tar.gz failed !!!"
@@ -17,15 +19,10 @@ if [ $? != 0 ]; then
 fi
 tar -zxvf libsndfile-1.0.28.tar.gz
 cd libsndfile-1.0.28
-./configure && make && make install
-cd -
+./configure --prefix=$DIR/thirdparty/libsndfile && make && make install
+cd ..
 rm -rf libsndfile-1.0.28
 rm libsndfile-1.0.28.tar.gz
-pip install SoundFile==0.9.0.post1
-if [ $? != 0 ]; then
-    echo "Install SoundFile failed !!!"
-    exit 1
-fi
 
 # prepare ./checkpoints
 mkdir checkpoints

--- a/deep_speech_2/setup.sh
+++ b/deep_speech_2/setup.sh
@@ -10,19 +10,21 @@ if [ $? != 0 ]; then
 fi
 
 # install package libsndfile
-DIR="$( cd "$(dirname "$0")" ; pwd -P )"
-mkdir thirdparty
-curl -O "http://www.mega-nerd.com/libsndfile/files/libsndfile-1.0.28.tar.gz"
+python -c "import soundfile"
 if [ $? != 0 ]; then
-    echo "Download libsndfile-1.0.28.tar.gz failed !!!"
-    exit 1
+    echo "Install package libsndfile into default system path."
+    curl -O "http://www.mega-nerd.com/libsndfile/files/libsndfile-1.0.28.tar.gz"
+    if [ $? != 0 ]; then
+        echo "Download libsndfile-1.0.28.tar.gz failed !!!"
+        exit 1
+    fi
+    tar -zxvf libsndfile-1.0.28.tar.gz
+    cd libsndfile-1.0.28
+    ./configure && make && make install
+    cd ..
+    rm -rf libsndfile-1.0.28
+    rm libsndfile-1.0.28.tar.gz
 fi
-tar -zxvf libsndfile-1.0.28.tar.gz
-cd libsndfile-1.0.28
-./configure --prefix=$DIR/thirdparty/libsndfile && make && make install
-cd ..
-rm -rf libsndfile-1.0.28
-rm libsndfile-1.0.28.tar.gz
 
 # prepare ./checkpoints
 mkdir checkpoints

--- a/deep_speech_2/tests/test_setup.py
+++ b/deep_speech_2/tests/test_setup.py
@@ -1,11 +1,22 @@
 """Test Setup."""
 import unittest
+import numpy as np
+import os
 
 
 class TestSetup(unittest.TestCase):
-    # test the installation of libsndfile library
     def test_soundfile(self):
-        import soundfile
+        import soundfile as sf
+        # floating point data is typically limited to the interval [-1.0, 1.0],
+        # but smaller/larger values are supported as well
+        data = np.array([[1.75, -1.75], [1.0, -1.0], [0.5, -0.5],
+                         [0.25, -0.25]])
+        file = 'test.wav'
+        sf.write(file, data, 44100, format='WAV', subtype='FLOAT')
+        read, fs = sf.read(file)
+        assert np.all(read == data)
+        assert fs == 44100
+        os.remove(file)
 
 
 if __name__ == '__main__':

--- a/deep_speech_2/tests/test_setup.py
+++ b/deep_speech_2/tests/test_setup.py
@@ -1,0 +1,12 @@
+"""Test Setup."""
+import unittest
+
+
+class TestSetup(unittest.TestCase):
+    # test the installation of libsndfile library
+    def test_soundfile(self):
+        import soundfile
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/deep_speech_2/tests/test_setup.py
+++ b/deep_speech_2/tests/test_setup.py
@@ -14,8 +14,8 @@ class TestSetup(unittest.TestCase):
         file = 'test.wav'
         sf.write(file, data, 44100, format='WAV', subtype='FLOAT')
         read, fs = sf.read(file)
-        assert np.all(read == data)
-        assert fs == 44100
+        self.assertTrue(np.all(read == data))
+        self.assertEqual(fs, 44100)
         os.remove(file)
 
 


### PR DESCRIPTION
1. 将SoundFile移到requirements.txt中安装。因为安装时不依赖libsndfile，只有使用时会依赖。
2. 如果系统中已经有libsndfile，则不安装。反之下载源码并安装系统路径。
    - 这里只能安装到系统路径，因为`ctypes.util.find_library()`只在系统路径中查找libsndfile库。
    - 在docker环境中，可以安装到系统路径。
3. 增加`soundfile.read/write`的单测。