### PR TITLE
make kenlm install more robust

### DIFF
--- a/deep_speech_2/requirements.txt
+++ b/deep_speech_2/requirements.txt
@@ -3,4 +3,4 @@ scipy==0.13.1
 resampy==0.1.5
 SoundFile==0.9.0.post1
 python_speech_features
-https://github.com/kpu/kenlm/archive/master.zip
+https://github.com/luotao1/kenlm/archive/master.zip


### PR DESCRIPTION
由于安装kenlm时经常会出现两个bug，因此fork了一个kenlm的分支，在自己的分支中修正了这两个bug：
https://github.com/luotao1/kenlm/commit/455cf139973f11cba893187229e9b9b0844a47cc
1. 移除`-std=c++11`
2. `util/mmap.cc`中`MAP_HUGETLB`的问题