### PR TITLE
change the wget method in run.sh of deep_speech2

### DIFF
--- a/deep_speech_2/datasets/librispeech/librispeech.py
+++ b/deep_speech_2/datasets/librispeech/librispeech.py
@@ -11,7 +11,7 @@ from __future__ import print_function
 
 import distutils.util
 import os
-import wget
+import sys
 import tarfile
 import argparse
 import soundfile
@@ -66,7 +66,7 @@ def download(url, md5sum, target_dir):
     filepath = os.path.join(target_dir, url.split("/")[-1])
     if not (os.path.exists(filepath) and md5file(filepath) == md5sum):
         print("Downloading %s ..." % url)
-        wget.download(url, target_dir)
+        os.system("wget -c " + url + " -P " + target_dir)
         print("\nMD5 Chesksum %s ..." % filepath)
         if not md5file(filepath) == md5sum:
             raise RuntimeError("MD5 checksum failed.")

--- a/deep_speech_2/requirements.txt
+++ b/deep_speech_2/requirements.txt
@@ -1,4 +1,3 @@
-wget==3.2
 scipy==0.13.1
 resampy==0.1.5
 SoundFile==0.9.0.post1


### PR DESCRIPTION
由于train-clean-100.tar.gz有6G，使用原先的`wget.download`时，下载到28%就kill了。因此修改wget方法为断点续传。
`-c`是断点续传，`-P`是写进指定目录。