### PR TITLE
Reset default multi-thread/process number to half of cpu count() for speedup.

### DIFF
--- a/deep_speech_2/data_utils/data.py
+++ b/deep_speech_2/data_utils/data.py
@@ -65,7 +65,7 @@ class DataGenerator(object):
                  max_freq=None,
                  specgram_type='linear',
                  use_dB_normalization=True,
-                 num_threads=multiprocessing.cpu_count(),
+                 num_threads=multiprocessing.cpu_count() // 2,
                  random_seed=0):
         self._max_duration = max_duration
         self._min_duration = min_duration

--- a/deep_speech_2/evaluate.py
+++ b/deep_speech_2/evaluate.py
@@ -45,12 +45,12 @@ parser.add_argument(
     help="Use gpu or not. (default: %(default)s)")
 parser.add_argument(
     "--num_threads_data",
-    default=multiprocessing.cpu_count(),
+    default=multiprocessing.cpu_count() // 2,
     type=int,
     help="Number of cpu threads for preprocessing data. (default: %(default)s)")
 parser.add_argument(
     "--num_processes_beam_search",
-    default=multiprocessing.cpu_count(),
+    default=multiprocessing.cpu_count() // 2,
     type=int,
     help="Number of cpu processes for beam search. (default: %(default)s)")
 parser.add_argument(

--- a/deep_speech_2/infer.py
+++ b/deep_speech_2/infer.py
@@ -45,7 +45,7 @@ parser.add_argument(
     help="Number of cpu threads for preprocessing data. (default: %(default)s)")
 parser.add_argument(
     "--num_processes_beam_search",
-    default=multiprocessing.cpu_count(),
+    default=multiprocessing.cpu_count() // 2,
     type=int,
     help="Number of cpu processes for beam search. (default: %(default)s)")
 parser.add_argument(

--- a/deep_speech_2/train.py
+++ b/deep_speech_2/train.py
@@ -86,7 +86,7 @@ parser.add_argument(
     help="Trainer number. (default: %(default)s)")
 parser.add_argument(
     "--num_threads_data",
-    default=multiprocessing.cpu_count(),
+    default=multiprocessing.cpu_count() // 2,
     type=int,
     help="Number of cpu threads for preprocessing data. (default: %(default)s)")
 parser.add_argument(

--- a/deep_speech_2/tune.py
+++ b/deep_speech_2/tune.py
@@ -51,7 +51,7 @@ parser.add_argument(
     help="Number of cpu threads for preprocessing data. (default: %(default)s)")
 parser.add_argument(
     "--num_processes_beam_search",
-    default=multiprocessing.cpu_count(),
+    default=multiprocessing.cpu_count() // 2,
     type=int,
     help="Number of cpu processes for beam search. (default: %(default)s)")
 parser.add_argument(


### PR DESCRIPTION
Change default thread/process number from `multiprocessing.cpu_count()` to `multiprocessing.cpu_count() // 2` to reduce thread/process competition. 