### PR TITLE
deep speech2 can directly use warpctc instead by export LD_LIBRARY_PATH

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+*.pyc

--- a/deep_speech_2/.gitignore
+++ b/deep_speech_2/.gitignore
@@ -1,0 +1,3 @@
+manifest*
+mean_std.npz
+thirdparty/

--- a/deep_speech_2/README.md
+++ b/deep_speech_2/README.md
@@ -4,7 +4,6 @@
 
 ```
 sh setup.sh
-export LD_LIBRARY_PATH=$PADDLE_INSTALL_DIR/Paddle/third_party/install/warpctc/lib:$LD_LIBRARY_PATH
 ```
 
 Please replace `$PADDLE_INSTALL_DIR` with your own paddle installation directory.

--- a/deep_speech_2/setup.sh
+++ b/deep_speech_2/setup.sh
@@ -13,7 +13,7 @@ fi
 python -c "import soundfile"
 if [ $? != 0 ]; then
     echo "Install package libsndfile into default system path."
-    curl -O "http://www.mega-nerd.com/libsndfile/files/libsndfile-1.0.28.tar.gz"
+    wget "http://www.mega-nerd.com/libsndfile/files/libsndfile-1.0.28.tar.gz"
     if [ $? != 0 ]; then
         echo "Download libsndfile-1.0.28.tar.gz failed !!!"
         exit 1


### PR DESCRIPTION
Inspired by https://github.com/PaddlePaddle/Paddle/pull/3503, we can directly use warpctc instead by export LD_LIBRARY_PATH.