### PR TITLE
rename mse into square_error after dev branch update.

### DIFF
--- a/ctr/network_conf.py
+++ b/ctr/network_conf.py
@@ -100,6 +100,6 @@ class CTRmodel(object):
         self.output = layer.fc(
             input=merge_layer, size=1, act=paddle.activation.Sigmoid())
         if not self.is_infer:
-            self.train_cost = paddle.layer.mse_cost(
+            self.train_cost = paddle.layer.square_error_cost(
                 input=self.output, label=self.click)
         return self.output

--- a/dssm/network_conf.py
+++ b/dssm/network_conf.py
@@ -270,7 +270,7 @@ class DSSM(object):
                 input=prediction, label=label)
         else:
             prediction = paddle.layer.cos_sim(*semantics)
-            cost = paddle.layer.mse_cost(prediction, label)
+            cost = paddle.layer.square_error_cost(prediction, label)
 
         if not self.is_infer:
             return cost, prediction, label


### PR DESCRIPTION
rename the `mse_cost` into `square_error_cost` after the latest update of Paddle's dev branch.