### PR TITLE
Revert back to support input-hidden weights sharing between bi-directional RNNs.

### DIFF
--- a/deep_speech_2/demo_server.py
+++ b/deep_speech_2/demo_server.py
@@ -63,9 +63,16 @@ parser.add_argument(
     help="RNN layer number. (default: %(default)s)")
 parser.add_argument(
     "--rnn_layer_size",
-    default=512,
+    default=2048,
     type=int,
     help="RNN layer cell number. (default: %(default)s)")
+parser.add_argument(
+    "--share_rnn_weights",
+    default=True,
+    type=distutils.util.strtobool,
+    help="Whether to share input-hidden weights between forword and backward "
+    "directional simple RNNs. Only available when use_gru=False. "
+    "(default: %(default)s)")
 parser.add_argument(
     "--use_gru",
     default=False,
@@ -205,7 +212,8 @@ def start_server():
         num_rnn_layers=args.num_rnn_layers,
         rnn_layer_size=args.rnn_layer_size,
         use_gru=args.use_gru,
-        pretrained_model_path=args.model_filepath)
+        pretrained_model_path=args.model_filepath,
+        share_rnn_weights=args.share_rnn_weights)
 
     # prepare ASR inference handler
     def file_to_transcript(filename):

--- a/deep_speech_2/evaluate.py
+++ b/deep_speech_2/evaluate.py
@@ -35,9 +35,16 @@ parser.add_argument(
     help="RNN layer number. (default: %(default)s)")
 parser.add_argument(
     "--rnn_layer_size",
-    default=512,
+    default=2048,
     type=int,
     help="RNN layer cell number. (default: %(default)s)")
+parser.add_argument(
+    "--share_rnn_weights",
+    default=True,
+    type=distutils.util.strtobool,
+    help="Whether to share input-hidden weights between forword and backward "
+    "directional simple RNNs. Only available when use_gru=False. "
+    "(default: %(default)s)")
 parser.add_argument(
     "--use_gru",
     default=False,
@@ -148,7 +155,8 @@ def evaluate():
         num_rnn_layers=args.num_rnn_layers,
         rnn_layer_size=args.rnn_layer_size,
         use_gru=args.use_gru,
-        pretrained_model_path=args.model_filepath)
+        pretrained_model_path=args.model_filepath,
+        share_rnn_weights=args.share_rnn_weights)
 
     error_rate_func = cer if args.error_rate_type == 'cer' else wer
     error_sum, num_ins = 0.0, 0

--- a/deep_speech_2/infer.py
+++ b/deep_speech_2/infer.py
@@ -30,9 +30,16 @@ parser.add_argument(
     help="RNN layer number. (default: %(default)s)")
 parser.add_argument(
     "--rnn_layer_size",
-    default=512,
+    default=2048,
     type=int,
     help="RNN layer cell number. (default: %(default)s)")
+parser.add_argument(
+    "--share_rnn_weights",
+    default=True,
+    type=distutils.util.strtobool,
+    help="Whether to share input-hidden weights between forword and backward "
+    "directional simple RNNs. Only available when use_gru=False. "
+    "(default: %(default)s)")
 parser.add_argument(
     "--use_gru",
     default=False,
@@ -149,7 +156,8 @@ def infer():
         num_rnn_layers=args.num_rnn_layers,
         rnn_layer_size=args.rnn_layer_size,
         use_gru=args.use_gru,
-        pretrained_model_path=args.model_filepath)
+        pretrained_model_path=args.model_filepath,
+        share_rnn_weights=args.share_rnn_weights)
     result_transcripts = ds2_model.infer_batch(
         infer_data=infer_data,
         decode_method=args.decode_method,

--- a/deep_speech_2/model.py
+++ b/deep_speech_2/model.py
@@ -27,12 +27,17 @@ class DeepSpeech2Model(object):
     :param pretrained_model_path: Pretrained model path. If None, will train
                                   from stratch.
     :type pretrained_model_path: basestring|None
+    :param share_rnn_weights: Whether to share input-hidden weights between
+                              forward and backward directional RNNs.Notice that
+                              for GRU, weight sharing is not supported.
+    :type share_rnn_weights: bool
     """
 
     def __init__(self, vocab_size, num_conv_layers, num_rnn_layers,
-                 rnn_layer_size, use_gru, pretrained_model_path):
+                 rnn_layer_size, use_gru, pretrained_model_path,
+                 share_rnn_weights):
         self._create_network(vocab_size, num_conv_layers, num_rnn_layers,
-                             rnn_layer_size, use_gru)
+                             rnn_layer_size, use_gru, share_rnn_weights)
         self._create_parameters(pretrained_model_path)
         self._inferer = None
         self._loss_inferer = None
@@ -226,7 +231,7 @@ class DeepSpeech2Model(object):
                 gzip.open(model_path))
 
     def _create_network(self, vocab_size, num_conv_layers, num_rnn_layers,
-                        rnn_layer_size, use_gru):
+                        rnn_layer_size, use_gru, share_rnn_weights):
         """Create data layers and model network."""
         # paddle.data_type.dense_array is used for variable batch input.
         # The size 161 * 161 is only an placeholder value and the real shape
@@ -244,4 +249,5 @@ class DeepSpeech2Model(object):
             num_conv_layers=num_conv_layers,
             num_rnn_layers=num_rnn_layers,
             rnn_size=rnn_layer_size,
-            use_gru=use_gru)
+            use_gru=use_gru,
+            share_rnn_weights=share_rnn_weights)

--- a/deep_speech_2/train.py
+++ b/deep_speech_2/train.py
@@ -37,9 +37,16 @@ parser.add_argument(
     help="RNN layer number. (default: %(default)s)")
 parser.add_argument(
     "--rnn_layer_size",
-    default=1024,
+    default=2048,
     type=int,
     help="RNN layer cell number. (default: %(default)s)")
+parser.add_argument(
+    "--share_rnn_weights",
+    default=True,
+    type=distutils.util.strtobool,
+    help="Whether to share input-hidden weights between forword and backward "
+    "directional simple RNNs. Only available when use_gru=False. "
+    "(default: %(default)s)")
 parser.add_argument(
     "--use_gru",
     default=False,
@@ -176,7 +183,8 @@ def train():
         num_rnn_layers=args.num_rnn_layers,
         rnn_layer_size=args.rnn_layer_size,
         use_gru=args.use_gru,
-        pretrained_model_path=args.init_model_path)
+        pretrained_model_path=args.init_model_path,
+        share_rnn_weights=args.share_rnn_weights)
     ds2_model.train(
         train_batch_reader=train_batch_reader,
         dev_batch_reader=dev_batch_reader,

--- a/deep_speech_2/tune.py
+++ b/deep_speech_2/tune.py
@@ -31,9 +31,16 @@ parser.add_argument(
     help="RNN layer number. (default: %(default)s)")
 parser.add_argument(
     "--rnn_layer_size",
-    default=512,
+    default=2048,
     type=int,
     help="RNN layer cell number. (default: %(default)s)")
+parser.add_argument(
+    "--share_rnn_weights",
+    default=True,
+    type=distutils.util.strtobool,
+    help="Whether to share input-hidden weights between forword and backward "
+    "directional simple RNNs. Only available when use_gru=False. "
+    "(default: %(default)s)")
 parser.add_argument(
     "--use_gru",
     default=False,
@@ -164,7 +171,8 @@ def tune():
         num_rnn_layers=args.num_rnn_layers,
         rnn_layer_size=args.rnn_layer_size,
         use_gru=args.use_gru,
-        pretrained_model_path=args.model_filepath)
+        pretrained_model_path=args.model_filepath,
+        share_rnn_weights=args.share_rnn_weights)
 
     # create grid for search
     cand_alphas = np.linspace(args.alpha_from, args.alpha_to, args.num_alphas)

--- a/deep_speech_2/utils.py
+++ b/deep_speech_2/utils.py
@@ -10,12 +10,12 @@ def print_arguments(args):
     Usage:
 
     .. code-block:: python
-        
+
         parser = argparse.ArgumentParser()
         parser.add_argument("name", default="Jonh", type=str, help="User name.")
-        args = parser.parse_args() 
+        args = parser.parse_args()
         print_arguments(args)
-    
+
     :param args: Input argparse.Namespace for printing.
     :type args: argparse.Namespace
     """


### PR DESCRIPTION
1. Add options to enable and disable RNN weights sharing.
2. Set rnn_layer_size to 2048 by default.
3. Revert back the striding steps of 1st conv layer from 2 to 3.
4. Revert Back to BRelu.

Above follows DS2 papers.