### PR TITLE
fix missing import

### DIFF
--- a/deep_speech_2/models/model.py
+++ b/deep_speech_2/models/model.py
@@ -10,6 +10,7 @@ import gzip
 import paddle.v2 as paddle
 from lm.lm_scorer import LmScorer
 from models.decoder import ctc_greedy_decoder, ctc_beam_search_decoder
+from models.decoder import ctc_beam_search_decoder_batch
 from models.network import deep_speech_v2_network
 
 


### PR DESCRIPTION
fix issue when infer ds2:

> 'ctc_beam_search_decoder_batch' is not defined 