### PR TITLE
Further speedup DS2 training by a) turning on FLAG_rnn_use_batch 2) improve data pipeline

### DIFF
--- a/deep_speech_2/infer.py
+++ b/deep_speech_2/infer.py
@@ -116,7 +116,9 @@ def infer():
 
 def main():
     print_arguments(args)
-    paddle.init(use_gpu=args.use_gpu, trainer_count=args.trainer_count)
+    paddle.init(use_gpu=args.use_gpu,
+                rnn_use_batch=True,
+                trainer_count=args.trainer_count)
     infer()
 
 

--- a/deep_speech_2/test.py
+++ b/deep_speech_2/test.py
@@ -119,7 +119,9 @@ def evaluate():
 
 def main():
     print_arguments(args)
-    paddle.init(use_gpu=args.use_gpu, trainer_count=args.trainer_count)
+    paddle.init(use_gpu=args.use_gpu,
+                rnn_use_batch=True,
+                trainer_count=args.trainer_count)
     evaluate()
 
 

--- a/deep_speech_2/tools/tune.py
+++ b/deep_speech_2/tools/tune.py
@@ -217,7 +217,9 @@ def tune():
 
 def main():
     print_arguments(args)
-    paddle.init(use_gpu=args.use_gpu, trainer_count=args.trainer_count)
+    paddle.init(use_gpu=args.use_gpu,
+                rnn_use_batch=True,
+                trainer_count=args.trainer_count)
     tune()
 
 

--- a/deep_speech_2/train.py
+++ b/deep_speech_2/train.py
@@ -119,6 +119,7 @@ def train():
 def main():
     print_arguments(args)
     paddle.init(use_gpu=args.use_gpu,
+                rnn_use_batch=True,
                 trainer_count=args.trainer_count,
                 log_clipping=True)
     train()


### PR DESCRIPTION
Resolved #358 

1. Setting `FLAG_rnn_use_batch` to `True` (default is `False`) might got more than 2X speedup for `paddle.layer.recurrent` layer.
2. Improve data pipeline: add a separate thread to read data from `Manager.Queue` and re-save to faster `Queue.Queue` in `xmap_reader_mp`. This save up 10% ~ 15% training time.