### PR TITLE
Website deploy scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,14 +16,21 @@ addons:
       - python
       - python-pip
       - python2.7-dev
+  ssh_known_hosts: 52.76.173.135
 before_install:
   -  sudo pip install -U virtualenv pre-commit pip
   -  docker pull paddlepaddle/paddle:latest
 script:
   -  .travis/precommit.sh
-  -  docker run -i --rm -v "$PWD:/py_unittest" paddlepaddle/paddle:latest /bin/bash -c 
+  -  docker run -i --rm -v "$PWD:/py_unittest" paddlepaddle/paddle:latest /bin/bash -c
     'cd /py_unittest; sh .travis/unittest.sh'
-
+  - |
+    if [[ "$TRAVIS_PULL_REQUEST" != "false" ]]; then exit 0; fi;
+    if [[ "$TRAVIS_BRANCH" != "develop"  && ! "$TRAVIS_BRANCH" =~ ^v[[:digit:]]+\.[[:digit:]]+(\.[[:digit:]]+)?(-\S*)?$ ]]; then echo "not develop branch, no deploy"; exit 0; fi;
+    export DEPLOY_DOCS_SH=https://raw.githubusercontent.com/PaddlePaddle/PaddlePaddle.org/master/scripts/deploy/deploy_docs.sh
+    export MODELS_DIR=`pwd`
+    cd ..
+    curl $DEPLOY_DOCS_SH | bash -s $CONTENT_DEC_PASSWD $TRAVIS_BRANCH $MODELS_DIR
 notifications:
   email:
     on_success: change


### PR DESCRIPTION
PaddlePaddle.org uses 'models' repo as a content source. This script will deploy the blog content to make it live on the new PaddlePaddle.org website.