### PR TITLE
use clang_format having the same version with the Paddle main repo.

### DIFF
--- a/.clang_format.hook
+++ b/.clang_format.hook
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
-readonly VERSION="3.9"
+readonly VERSION="3.8"
 
 version=$(clang-format -version)
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,10 +16,10 @@ addons:
       - python
       - python-pip
       - python2.7-dev
-      - clang-format-3.9
+      - clang-format-3.8
   ssh_known_hosts: 52.76.173.135
 before_install:
-  - if [[ "$JOB" == "PRE_COMMIT" ]]; then sudo ln -s /usr/bin/clang-format-3.9 /usr/bin/clang-format; fi
+  - if [[ "$JOB" == "PRE_COMMIT" ]]; then sudo ln -s /usr/bin/clang-format-3.8 /usr/bin/clang-format; fi
   - sudo pip install -U virtualenv pre-commit pip
   - docker pull paddlepaddle/paddle:latest
 


### PR DESCRIPTION
use the clang format having the same version of the PaddlePaddle main repo.
fixes https://github.com/PaddlePaddle/models/issues/553