### PR TITLE
move paddle.v2.fluid to paddle.fluid

### DIFF
--- a/fluid/DeepASR/infer.py
+++ b/fluid/DeepASR/infer.py
@@ -4,7 +4,7 @@ from __future__ import print_function
 
 import os
 import argparse
-import paddle.v2.fluid as fluid
+import paddle.fluid as fluid
 import data_utils.augmentor.trans_mean_variance_norm as trans_mean_variance_norm
 import data_utils.augmentor.trans_add_delta as trans_add_delta
 import data_utils.augmentor.trans_splice as trans_splice

--- a/fluid/DeepASR/model_utils/model.py
+++ b/fluid/DeepASR/model_utils/model.py
@@ -3,7 +3,7 @@ from __future__ import division
 from __future__ import print_function
 
 import paddle.v2 as paddle
-import paddle.v2.fluid as fluid
+import paddle.fluid as fluid
 
 
 def stacked_lstmp_model(hidden_dim,

--- a/fluid/DeepASR/tools/profile.py
+++ b/fluid/DeepASR/tools/profile.py
@@ -7,8 +7,8 @@ import numpy as np
 import argparse
 import time
 
-import paddle.v2.fluid as fluid
-import paddle.v2.fluid.profiler as profiler
+import paddle.fluid as fluid
+import paddle.fluid.profiler as profiler
 import _init_paths
 import data_utils.augmentor.trans_mean_variance_norm as trans_mean_variance_norm
 import data_utils.augmentor.trans_add_delta as trans_add_delta

--- a/fluid/DeepASR/train.py
+++ b/fluid/DeepASR/train.py
@@ -8,7 +8,7 @@ import numpy as np
 import argparse
 import time
 
-import paddle.v2.fluid as fluid
+import paddle.fluid as fluid
 import data_utils.augmentor.trans_mean_variance_norm as trans_mean_variance_norm
 import data_utils.augmentor.trans_add_delta as trans_add_delta
 import data_utils.augmentor.trans_splice as trans_splice

--- a/fluid/adversarial/advbox/models/paddle.py
+++ b/fluid/adversarial/advbox/models/paddle.py
@@ -4,7 +4,7 @@ Paddle model
 from __future__ import absolute_import
 
 import numpy as np
-import paddle.v2.fluid as fluid
+import paddle.fluid as fluid
 
 from .base import Model
 
@@ -16,7 +16,7 @@ class PaddleModel(Model):
     instance of PaddleModel.
 
     Args:
-        program(paddle.v2.fluid.framework.Program): The program of the model
+        program(paddle.fluid.framework.Program): The program of the model
             which generate the adversarial sample.
         input_name(string): The name of the input.
         logits_name(string): The name of the logits.

--- a/fluid/adversarial/fluid_mnist.py
+++ b/fluid/adversarial/fluid_mnist.py
@@ -2,7 +2,7 @@
 CNN on mnist data using fluid api of paddlepaddle
 """
 import paddle.v2 as paddle
-import paddle.v2.fluid as fluid
+import paddle.fluid as fluid
 
 
 def mnist_cnn_model(img):

--- a/fluid/adversarial/mnist_tutorial_fgsm.py
+++ b/fluid/adversarial/mnist_tutorial_fgsm.py
@@ -3,7 +3,7 @@ FGSM demos on mnist using advbox tool.
 """
 import matplotlib.pyplot as plt
 import paddle.v2 as paddle
-import paddle.v2.fluid as fluid
+import paddle.fluid as fluid
 
 from advbox import Adversary
 from advbox.attacks.gradientsign import GradientSignAttack

--- a/fluid/adversarial/mnist_tutorial_jsma.py
+++ b/fluid/adversarial/mnist_tutorial_jsma.py
@@ -3,7 +3,7 @@ FGSM demos on mnist using advbox tool.
 """
 import matplotlib.pyplot as plt
 import paddle.v2 as paddle
-import paddle.v2.fluid as fluid
+import paddle.fluid as fluid
 import numpy as np
 
 from advbox import Adversary

--- a/fluid/image_classification/mobilenet.py
+++ b/fluid/image_classification/mobilenet.py
@@ -1,9 +1,9 @@
 import os
 
 import paddle.v2 as paddle
-import paddle.v2.fluid as fluid
-from paddle.v2.fluid.initializer import MSRA
-from paddle.v2.fluid.param_attr import ParamAttr
+import paddle.fluid as fluid
+from paddle.fluid.initializer import MSRA
+from paddle.fluid.param_attr import ParamAttr
 
 parameter_attr = ParamAttr(initializer=MSRA())
 

--- a/fluid/image_classification/se_resnext.py
+++ b/fluid/image_classification/se_resnext.py
@@ -1,6 +1,6 @@
 import os
 import paddle.v2 as paddle
-import paddle.v2.fluid as fluid
+import paddle.fluid as fluid
 import reader
 
 

--- a/fluid/policy_gradient/brain.py
+++ b/fluid/policy_gradient/brain.py
@@ -1,6 +1,6 @@
 import numpy as np
 import paddle.v2 as paddle
-import paddle.v2.fluid as fluid
+import paddle.fluid as fluid
 # reproducible
 np.random.seed(1)
 

--- a/fluid/text_classification/train.py
+++ b/fluid/text_classification/train.py
@@ -5,7 +5,7 @@ import argparse
 import time
 
 import paddle.v2 as paddle
-import paddle.v2.fluid as fluid
+import paddle.fluid as fluid
 
 from config import TrainConfig as conf
 

--- a/fluid/transformer/model.py
+++ b/fluid/transformer/model.py
@@ -2,8 +2,8 @@ from functools import partial
 import numpy as np
 
 import paddle.v2 as paddle
-import paddle.v2.fluid as fluid
-import paddle.v2.fluid.layers as layers
+import paddle.fluid as fluid
+import paddle.fluid.layers as layers
 
 from config import TrainTaskConfig, input_data_names, pos_enc_param_names
 

--- a/fluid/transformer/train.py
+++ b/fluid/transformer/train.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 import paddle.v2 as paddle
-import paddle.v2.fluid as fluid
+import paddle.fluid as fluid
 
 from model import transformer, position_encoding_init
 from config import TrainTaskConfig, ModelHyperParams, \


### PR DESCRIPTION
Since https://github.com/PaddlePaddle/Paddle/pull/8548 move Fluid API doc/code out of V2 API doc/code, this PR move `paddle.v2.fluid` to `paddle.fluid` in models repo.