### PR TITLE
caffe2fluid: support intermediate layer precision compare

### DIFF
--- a/fluid/image_classification/caffe2fluid/examples/imagenet/compare.py
+++ b/fluid/image_classification/caffe2fluid/examples/imagenet/compare.py
@@ -20,8 +20,8 @@ def calc_diff(f1, f2):
     d1 = np.load(f1)
     d2 = np.load(f2)
 
-    print d1.shape
-    print d2.shape
+    #print d1.shape
+    #print d2.shape
     #print d1[0, 0, 0:10, 0:10]
     #print d2[0, 0, 0:10, 0:10]
     #d1 = d1[:, :, 1:-2, 1:-2]

--- a/fluid/image_classification/caffe2fluid/examples/imagenet/tools/cmp.sh
+++ b/fluid/image_classification/caffe2fluid/examples/imagenet/tools/cmp.sh
@@ -19,4 +19,6 @@ if [[ $# -eq 3 ]];then
 else
     caffe_file="./results/${model_name}.caffe/${2}.npy"
 fi
-python ./compare.py $paddle_file $caffe_file
+cmd="python ./compare.py $paddle_file $caffe_file"
+echo $cmd
+eval $cmd

--- a/fluid/image_classification/caffe2fluid/examples/imagenet/tools/diff.sh
+++ b/fluid/image_classification/caffe2fluid/examples/imagenet/tools/diff.sh
@@ -29,8 +29,8 @@ fi
 
 mkdir -p $results_root
 
-model_prototxt="models.caffe/$model_name/${model_name}.prototxt"
-model_caffemodel="models.caffe/${model_name}/${model_name}.caffemodel"
+prototxt="models.caffe/$model_name/${model_name}.prototxt"
+caffemodel="models.caffe/${model_name}/${model_name}.caffemodel"
 
 #1, dump layers' results from paddle
 paddle_results="$results_root/${model_name}.paddle"
@@ -51,7 +51,7 @@ PYTHON=`which cfpython`
 if [[ -z $PYTHON ]];then
     PYTHON=`which python`
 fi
-$PYTHON ./infer.py caffe $model_prototxt $model_caffemodel $paddle_results/data.npy
+$PYTHON ./infer.py caffe $prototxt $caffemodel $paddle_results/data.npy
 if [[ $? -ne 0 ]] || [[ ! -e "results.caffe" ]];then
     echo "not found caffe's results, maybe failed to do inference with caffe"
     exit 1
@@ -59,10 +59,25 @@ fi
 mv results.caffe $caffe_results
 
 #3, extract layer names
-cat $model_prototxt | grep name | perl -ne 'if(/^\s*name:\s+\"([^\"]+)/){ print $1."\n";}' >.layer_names
+cat $prototxt | grep name | perl -ne 'if(/^\s*name\s*:\s+\"([^\"]+)/){ print $1."\n";}' >.layer_names
+
+final_layer=$(cat $prototxt | perl -ne 'if(/^\s*top\s*:\s+\"([^\"]+)/){ print $1."\n";}' | tail -n1)
+ret=$(grep "^$final_layer$" .layer_names | wc -l)
+if [[ $ret -eq 0 ]];then
+    echo $final_layer >>.layer_names
+fi
 
 #4, compare one by one
-for i in $(cat ".layer_names" | tail -n1);do
+#for i in $(cat .layer_names);do
+for i in $(cat .layer_names | tail -n1);do
+    i=${i//\//_}
     echo "process $i"
-    $PYTHON compare.py $caffe_results/${i}.npy $paddle_results/${i}.npy
+    pd_npy=$(find $paddle_results/ -iname "${i}.*npy" | grep deleted -v | head -n1)
+    #pd_npy="$paddle_results/${i}.npy"
+    if [[ -f $pd_npy ]];then
+        $PYTHON compare.py $caffe_results/${i}.npy $pd_npy
+    else
+        echo "not found npy file[${i}.*npy] for layer[$i]"
+        exit 1
+    fi
 done

--- a/fluid/image_classification/caffe2fluid/examples/imagenet/tools/run.sh
+++ b/fluid/image_classification/caffe2fluid/examples/imagenet/tools/run.sh
@@ -71,7 +71,9 @@ if [[ -z $only_convert ]];then
     if [[ -z $net_name ]];then
         net_name="MyNet"
     fi
-    $PYTHON ./infer.py dump $net_file $weight_file $imgfile $net_name
+    cmd="$PYTHON ./infer.py dump $net_file $weight_file $imgfile $net_name"
+    echo $cmd
+    eval $cmd
     ret=$?
 fi
 exit $ret

--- a/fluid/image_classification/caffe2fluid/examples/imagenet/tools/test.sh
+++ b/fluid/image_classification/caffe2fluid/examples/imagenet/tools/test.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+#
+#script to test all models
+#
+
+models="alexnet vgg16 googlenet resnet152 resnet101 resnet50"
+for i in $models;do
+    echo "begin to process $i"
+    bash ./tools/diff.sh $i 2>&1
+    echo "finished to process $i with ret[$?]"
+done

--- a/fluid/image_classification/caffe2fluid/kaffe/custom_layers/argmax.py
+++ b/fluid/image_classification/caffe2fluid/kaffe/custom_layers/argmax.py
@@ -58,11 +58,13 @@ def argmax_layer(input, name, out_max_val=False, top_k=1, axis=-1):
     if axis < 0:
         axis += len(input.shape)
 
-    topk_var, index_var = fluid.layers.topk(input=input, k=top_k)
     if out_max_val is True:
+        topk_var, index_var = fluid.layers.topk(input=input, k=top_k)
         index_var = fluid.layers.cast(index_var, dtype=topk_var.dtype)
-        output = fluid.layers.concat([index_var, topk_var], axis=axis)
+        output = fluid.layers.concat(
+            [index_var, topk_var], axis=axis, name=name)
     else:
+        topk_var, index_var = fluid.layers.topk(input=input, k=top_k, name=name)
         output = index_var
 
     return output

--- a/fluid/image_classification/caffe2fluid/kaffe/custom_layers/axpy.py
+++ b/fluid/image_classification/caffe2fluid/kaffe/custom_layers/axpy.py
@@ -43,7 +43,7 @@ def axpy_layer(inputs, name):
     x = inputs[1]
     y = inputs[2]
     output = fluid.layers.elementwise_mul(x, alpha, axis=0)
-    output = fluid.layers.elementwise_add(output, y)
+    output = fluid.layers.elementwise_add(output, y, name=name)
 
     return output
 

--- a/fluid/image_classification/caffe2fluid/kaffe/layers.py
+++ b/fluid/image_classification/caffe2fluid/kaffe/layers.py
@@ -216,7 +216,7 @@ class LayerAdapter(object):
         s_w = self.get_kernel_value(
             params.stride_w, params.stride, 1, default=1)
         p_h = self.get_kernel_value(params.pad_h, params.pad, 0, default=0)
-        p_w = self.get_kernel_value(params.pad_h, params.pad, 1, default=0)
+        p_w = self.get_kernel_value(params.pad_w, params.pad, 1, default=0)
         return KernelParameters(k_h, k_w, s_h, s_w, p_h, p_w)
 
 

--- a/fluid/image_classification/caffe2fluid/kaffe/paddle/network.py
+++ b/fluid/image_classification/caffe2fluid/kaffe/paddle/network.py
@@ -47,6 +47,8 @@ class Network(object):
         self.trainable = trainable
         # Switch variable for dropout
         self.paddle_env = None
+        self.output_names = []
+        self.name_trace = None
         self.setup()
 
     def setup(self):
@@ -79,6 +81,10 @@ class Network(object):
 
         data_dict = np.load(data_path).item()
         for op_name in data_dict:
+            if op_name == 'caffe2fluid_name_trace':
+                self.name_trace = data_dict[op_name]
+                continue
+
             layer = self.layers[op_name]
             for param_name, data in data_dict[op_name].iteritems():
                 try:
@@ -117,6 +123,15 @@ class Network(object):
         ident = sum(t.startswith(prefix) for t, _ in self.layers.items()) + 1
         return '%s_%d' % (prefix, ident)
 
+    def get_unique_output_name(self, prefix, layertype):
+        '''Returns an index-suffixed unique name for the given prefix.
+            This is used for auto-generating layer names based on the type-prefix.
+        '''
+        ident = sum(t.startswith(prefix) for t in self.output_names) + 1
+        unique_name = '%s.%s.output.%d' % (prefix, layertype, ident)
+        self.output_names.append(unique_name)
+        return unique_name
+
     @layer
     def conv(self,
              input,
@@ -152,6 +167,7 @@ class Network(object):
             act = None
 
         output = fluid.layers.conv2d(
+            name=self.get_unique_output_name(name, 'conv2d'),
             input=input,
             filter_size=[k_h, k_w],
             num_filters=c_o,
@@ -170,7 +186,8 @@ class Network(object):
     @layer
     def relu(self, input, name):
         fluid = import_fluid()
-        output = fluid.layers.relu(x=input)
+        output = fluid.layers.relu(
+            name=self.get_unique_output_name(name, 'relu'), x=input)
         return output
 
     def pool(self, pool_type, input, k_h, k_w, s_h, s_w, ceil_mode, padding,
@@ -182,6 +199,7 @@ class Network(object):
 
         fluid = import_fluid()
         output = fluid.layers.pool2d(
+            name=name,
             input=input,
             pool_size=k_hw,
             pool_stride=s_hw,
@@ -200,8 +218,16 @@ class Network(object):
                  ceil_mode,
                  padding=[0, 0],
                  name=None):
-        return self.pool('max', input, k_h, k_w, s_h, s_w, ceil_mode, padding,
-                         name)
+        return self.pool(
+            'max',
+            input,
+            k_h,
+            k_w,
+            s_h,
+            s_w,
+            ceil_mode,
+            padding,
+            name=self.get_unique_output_name(name, 'max_pool'))
 
     @layer
     def avg_pool(self,
@@ -213,25 +239,41 @@ class Network(object):
                  ceil_mode,
                  padding=[0, 0],
                  name=None):
-        return self.pool('avg', input, k_h, k_w, s_h, s_w, ceil_mode, padding,
-                         name)
+        return self.pool(
+            'avg',
+            input,
+            k_h,
+            k_w,
+            s_h,
+            s_w,
+            ceil_mode,
+            padding,
+            name=self.get_unique_output_name(name, 'avg_pool'))
 
     @layer
     def sigmoid(self, input, name):
         fluid = import_fluid()
-        return fluid.layers.sigmoid(input)
+        return fluid.layers.sigmoid(
+            input, name=self.get_unique_output_name(name, 'sigmoid'))
 
     @layer
     def lrn(self, input, radius, alpha, beta, name, bias=1.0):
         fluid = import_fluid()
-        output = fluid.layers.lrn(input=input, \
-                n=radius, k=bias, alpha=alpha, beta=beta, name=name)
+        output = fluid.layers.lrn(input=input,
+                                  n=radius,
+                                  k=bias,
+                                  alpha=alpha,
+                                  beta=beta,
+                                  name=self.get_unique_output_name(name, 'lrn'))
         return output
 
     @layer
     def concat(self, inputs, axis, name):
         fluid = import_fluid()
-        output = fluid.layers.concat(input=inputs, axis=axis)
+        output = fluid.layers.concat(
+            input=inputs,
+            axis=axis,
+            name=self.get_unique_output_name(name, 'concat'))
         return output
 
     @layer
@@ -239,7 +281,8 @@ class Network(object):
         fluid = import_fluid()
         output = inputs[0]
         for i in inputs[1:]:
-            output = fluid.layers.elementwise_add(x=output, y=i)
+            output = fluid.layers.elementwise_add(
+                x=output, y=i, name=self.get_unique_output_name(name, 'add'))
         return output
 
     @layer
@@ -251,7 +294,7 @@ class Network(object):
 
         prefix = name + '_'
         output = fluid.layers.fc(
-            name=name,
+            name=self.get_unique_output_name(name, 'fc'),
             input=input,
             size=num_out,
             act=act,
@@ -269,7 +312,8 @@ class Network(object):
                     str(shape))
             input = fluid.layers.reshape(input, shape[0:2])
 
-        output = fluid.layers.softmax(input)
+        output = fluid.layers.softmax(
+            input, name=self.get_unique_output_name(name, 'softmax'))
         return output
 
     @layer
@@ -289,7 +333,7 @@ class Network(object):
         mean_name = prefix + 'mean'
         variance_name = prefix + 'variance'
         output = fluid.layers.batch_norm(
-            name=name,
+            name=self.get_unique_output_name(name, 'batch_norm'),
             input=input,
             is_test=True,
             param_attr=param_attr,
@@ -308,7 +352,10 @@ class Network(object):
             output = input
         else:
             output = fluid.layers.dropout(
-                input, dropout_prob=drop_prob, is_test=is_test)
+                input,
+                dropout_prob=drop_prob,
+                is_test=is_test,
+                name=self.get_unique_output_name(name, 'dropout'))
         return output
 
     @layer
@@ -328,8 +375,16 @@ class Network(object):
         offset_param = fluid.layers.create_parameter(
             shape=scale_shape, dtype=input.dtype, name=name, attr=offset_attr)
 
-        output = fluid.layers.elementwise_mul(input, scale_param, axis=axis)
-        output = fluid.layers.elementwise_add(output, offset_param, axis=axis)
+        output = fluid.layers.elementwise_mul(
+            input,
+            scale_param,
+            axis=axis,
+            name=self.get_unique_output_name(name, 'scale_mul'))
+        output = fluid.layers.elementwise_add(
+            output,
+            offset_param,
+            axis=axis,
+            name=self.get_unique_output_name(name, 'scale_add'))
         return output
 
     def custom_layer_factory(self):
@@ -342,5 +397,6 @@ class Network(object):
     def custom_layer(self, inputs, kind, name, *args, **kwargs):
         """ make custom layer
         """
+        name = self.get_unique_output_name(name, kind)
         layer_factory = self.custom_layer_factory()
         return layer_factory(kind, inputs, name, *args, **kwargs)

--- a/fluid/image_classification/caffe2fluid/kaffe/transformers.py
+++ b/fluid/image_classification/caffe2fluid/kaffe/transformers.py
@@ -181,6 +181,20 @@ class SubNodeFuser(object):
     '''
     An abstract helper for merging a single-child with its single-parent.
     '''
+    _traced_names = {}
+
+    @classmethod
+    def traced_names(cls):
+        return cls._traced_names
+
+    @classmethod
+    def trace(cls, fname, tname):
+        """ recording the names mapping,
+            the value of 'fname' will be replaced by value of 'tname'
+        """
+        if fname not in cls._traced_names:
+            cls._traced_names[fname] = []
+        cls._traced_names[fname].append(tname)
 
     def __call__(self, graph):
         nodes = graph.nodes
@@ -234,6 +248,7 @@ class ReLUFuser(SubNodeFuser):
                 child.kind == NodeKind.ReLU)
 
     def merge(self, parent, child):
+        SubNodeFuser.trace(parent.name, child.name)
         parent.metadata['relu'] = True
         parent.metadata['relu_negative_slope'] = child.parameters.negative_slope
 
@@ -255,6 +270,7 @@ class BatchNormScaleBiasFuser(SubNodeFuser):
                 child.parameters.bias_term == True)
 
     def merge(self, parent, child):
+        SubNodeFuser.trace(parent.name, child.name)
         parent.scale_bias_node = child
 
 


### PR DESCRIPTION
new features:
1, add name mapping from caffe to fluid (useful for debug)
2, support to compare intermediate layer's outputs when comparing their precision difference

fixed bugs:
1, fix bug in failed to convert model when pad_h or pad_w is zero and the other is not