### PR TITLE
fix format of deepqnetwork doc

### DIFF
--- a/fluid/DeepQNetwork/README.md
+++ b/fluid/DeepQNetwork/README.md
@@ -1,7 +1,7 @@
 [中文版](README_cn.md)
 
 ## Reproduce DQN, DoubleDQN, DuelingDQN model with Fluid version of PaddlePaddle
-Based on PaddlePaddle's next-generation API Fluid, the DQN model of deep reinforcement learning is reproduced, and the same level of indicators of the paper is reproduced in the classic Atari game. The model receives the image of the game as input, and uses the end-to-end model to directly predict the next step. The repository contains the following three types of models.
+Based on PaddlePaddle's next-generation API Fluid, the DQN model of deep reinforcement learning is reproduced, and the same level of indicators of the paper is reproduced in the classic Atari game. The model receives the image of the game as input, and uses the end-to-end model to directly predict the next step. The repository contains the following three types of models:
 + DQN in
 [Human-level Control Through Deep Reinforcement Learning](http://www.nature.com/nature/journal/v518/n7540/full/nature14236.html)
 + DoubleDQN in:
@@ -10,11 +10,18 @@ Based on PaddlePaddle's next-generation API Fluid, the DQN model of deep reinfor
 [Dueling Network Architectures for Deep Reinforcement Learning](http://proceedings.mlr.press/v48/wangf16.html)
 
 ## Atari benchmark & performance
-### [Atari games introduction](https://gym.openai.com/envs/#atari)
+
+### Atari games introduction
+
+Please see [here](https://gym.openai.com/envs/#atari) to know more about Atari game.
 
 ### Pong game result
+
 The average game rewards that can be obtained for the three models as the number of training steps changes during the training are as follows(about 3 hours/1 Million steps):
-![DQN result](assets/dqn.png)
+
+<div align="center">
+<img src="assets/dqn.png" width="600" height="300" alt="DQN result"></img>
+</div>
 
 ## How to use
 ### Dependencies:
@@ -33,7 +40,7 @@ The average game rewards that can be obtained for the three models as the number
     pip install -r requirement.txt
     pip install gym[atari]
     ```
-    Install ale_python_interface, can reference：https://github.com/mgbellemare/Arcade-Learning-Environment
+    Install ale_python_interface, please see [here](https://github.com/mgbellemare/Arcade-Learning-Environment).
 
 ### Start Training:
 ```
@@ -47,7 +54,7 @@ python train.py --rom ./rom_files/pong.bin --use_cuda --alg DoubleDQN
 python train.py --rom ./rom_files/pong.bin --use_cuda --alg DuelingDQN
 ```
 
-To train more games, can install more rom files from [here](https://github.com/openai/atari-py/tree/master/atari_py/atari_roms)
+To train more games, you can install more rom files from [here](https://github.com/openai/atari-py/tree/master/atari_py/atari_roms).
 
 ### Start Testing:
 ```

--- a/fluid/DeepQNetwork/README_cn.md
+++ b/fluid/DeepQNetwork/README_cn.md
@@ -1,5 +1,6 @@
 ## 基于PaddlePaddle的Fluid版本复现DQN, DoubleDQN, DuelingDQN三个模型
-基于PaddlePaddle下一代API Fluid复现了深度强化学习领域的DQN模型，在经典的Atari 游戏上复现了论文同等水平的指标，模型接收游戏的图像作为输入，采用端到端的模型直接预测下一步要执行的控制信号，本仓库一共包含以下3类模型。
+
+基于PaddlePaddle下一代API Fluid复现了深度强化学习领域的DQN模型，在经典的Atari 游戏上复现了论文同等水平的指标，模型接收游戏的图像作为输入，采用端到端的模型直接预测下一步要执行的控制信号，本仓库一共包含以下3类模型：
 + DQN模型：
 [Human-level Control Through Deep Reinforcement Learning](http://www.nature.com/nature/journal/v518/n7540/full/nature14236.html)
 + DoubleDQN模型：
@@ -8,13 +9,20 @@
 [Dueling Network Architectures for Deep Reinforcement Learning](http://proceedings.mlr.press/v48/wangf16.html)
 
 ## 模型效果：Atari游戏表现
-### [Atari游戏介绍](https://gym.openai.com/envs/#atari)
+
+### Atari游戏介绍
+
+请点击[这里](https://gym.openai.com/envs/#atari)了解Atari游戏。
 
 ### Pong游戏训练结果
 三个模型在训练过程中随着训练步数的变化，能得到的平均游戏奖励如下图所示（大概3小时每1百万步）：
-![DQN result](assets/dqn.png)
+
+<div align="center">
+<img src="assets/dqn.png" width="600" height="300" alt="DQN result"></img>
+</div>
 
 ## 使用教程
+
 ### 依赖:
 + python2.7
 + gym
@@ -24,6 +32,7 @@
 + ale_python_interface
 
 ### 下载依赖：
+
 + 安装PaddlePaddle：
     建议通过PaddlePaddle源码进行编译安装  
 + 下载其它依赖：
@@ -31,9 +40,10 @@
     pip install -r requirement.txt
     pip install gym[atari]
     ```
-    安装ale_python_interface可以参考：https://github.com/mgbellemare/Arcade-Learning-Environment
+    安装ale_python_interface可以参考[这里](https://github.com/mgbellemare/Arcade-Learning-Environment)
 
 ### 训练模型：
+
 ```
 # 使用GPU训练Pong游戏（默认使用DQN模型）
 python train.py --rom ./rom_files/pong.bin --use_cuda
@@ -45,9 +55,10 @@ python train.py --rom ./rom_files/pong.bin --use_cuda --alg DoubleDQN
 python train.py --rom ./rom_files/pong.bin --use_cuda --alg DuelingDQN
 ```
 
-训练更多游戏，可以下载游戏rom从[这里](https://github.com/openai/atari-py/tree/master/atari_py/atari_roms)
+训练更多游戏，可以从[这里](https://github.com/openai/atari-py/tree/master/atari_py/atari_roms)下载游戏rom
 
 ### 测试模型：
+
 ```
 # Play the game with saved model and calculate the average rewards
 # 使用训练过程中保存的最好模型玩游戏，以及计算平均奖励（rewards）
@@ -56,4 +67,5 @@ python play.py --rom ./rom_files/pong.bin --use_cuda --model_path ./saved_model/
 # 以可视化的形式来玩游戏
 python play.py --rom ./rom_files/pong.bin --use_cuda --model_path ./saved_model/DQN-pong --viz 0.01
 ```
+
 [这里](https://pan.baidu.com/s/1gIsbNw5V7tMeb74ojx-TMA)是Pong和Breakout游戏训练好的模型，可以直接用来测试。


### PR DESCRIPTION
参照了网上的资料把图片写成了居中格式，但似乎预览出来的还是靠左的。
可能在官网显示的时候能够居中。