### PR TITLE
Port sequence_tagging_for_ner to Python3

### DIFF
--- a/fluid/sequence_tagging_for_ner/train.py
+++ b/fluid/sequence_tagging_for_ner/train.py
@@ -1,7 +1,10 @@
+from __future__ import print_function
+
 import os
 import math
 import time
 import numpy as np
+import six
 
 import paddle
 import paddle.fluid as fluid
@@ -15,9 +18,9 @@ from utils_extend import to_lodtensor, get_embedding
 def test(exe, chunk_evaluator, inference_program, test_data, place):
     chunk_evaluator.reset(exe)
     for data in test_data():
-        word = to_lodtensor(map(lambda x: x[0], data), place)
-        mark = to_lodtensor(map(lambda x: x[1], data), place)
-        target = to_lodtensor(map(lambda x: x[2], data), place)
+        word = to_lodtensor([x[0] for x in data], place)
+        mark = to_lodtensor([x[1] for x in data], place)
+        target = to_lodtensor([x[2] for x in data], place)
         acc = exe.run(inference_program,
                       feed={"word": word,
                             "mark": mark,
@@ -97,7 +100,7 @@ def main(train_data_file,
     embedding_param = fluid.global_scope().find_var(embedding_name).get_tensor()
     embedding_param.set(word_vector_values, place)
 
-    for pass_id in xrange(num_passes):
+    for pass_id in six.moves.xrange(num_passes):
         chunk_evaluator.reset(exe)
         for batch_id, data in enumerate(train_reader()):
             cost, batch_precision, batch_recall, batch_f1_score = exe.run(
@@ -142,6 +145,5 @@ if __name__ == "__main__":
         emb_file="data/wordVectors.txt",
         model_save_dir="models",
         num_passes=1000,
-        batch_size=1,
         use_gpu=False,
         parallel=False)


### PR DESCRIPTION
What we get in Python3 env

```
[TestSet] pass_id:993 pass_precision:[1.] pass_recall:[0.0625] pass_f1_score:[0.11764706]                                                                                [266/1816]
[9.785494]                                                                                                                                                                         
Pass 994, Batch 0, Cost 9.785494, Precision 1.0, Recall 0.13333334, F1_score0.23529413                                                                                             
[TrainSet] pass_id:994 pass_precision:[1.] pass_recall:[0.13333334] pass_f1_score:[0.23529412]                                                                                     
[TestSet] pass_id:994 pass_precision:[0.] pass_recall:[0.] pass_f1_score:[0.]                                                                                                      
[9.235923]                                                                                                                                                                         
Pass 995, Batch 0, Cost 9.235923, Precision 0.6666667, Recall 0.13333334, F1_score0.22222224                                                                                       
[TrainSet] pass_id:995 pass_precision:[0.6666667] pass_recall:[0.13333334] pass_f1_score:[0.22222222]                                                                              
[TestSet] pass_id:995 pass_precision:[1.] pass_recall:[0.0625] pass_f1_score:[0.11764706]                                                                                          
[9.701894]                                                                                                                                                                         
Pass 996, Batch 0, Cost 9.701894, Precision 1.0, Recall 0.13333334, F1_score0.23529413                                                                                             
[TrainSet] pass_id:996 pass_precision:[1.] pass_recall:[0.13333334] pass_f1_score:[0.23529412]                
[TestSet] pass_id:996 pass_precision:[0.] pass_recall:[0.] pass_f1_score:[0.]    
[9.249712]                                                                    
Pass 997, Batch 0, Cost 9.249712, Precision 0.6666667, Recall 0.13333334, F1_score0.22222224                                                                              
[TrainSet] pass_id:997 pass_precision:[0.6666667] pass_recall:[0.13333334] pass_f1_score:[0.22222222]
[TestSet] pass_id:997 pass_precision:[1.] pass_recall:[0.0625] pass_f1_score:[0.11764706]                                                                                 
[9.772681]               
Pass 998, Batch 0, Cost 9.772681, Precision 1.0, Recall 0.13333334, F1_score0.23529413
[TrainSet] pass_id:998 pass_precision:[1.] pass_recall:[0.13333334] pass_f1_score:[0.23529412]
[TestSet] pass_id:998 pass_precision:[0.] pass_recall:[0.] pass_f1_score:[0.]                                                                                             
[9.213273]               
Pass 999, Batch 0, Cost 9.213273, Precision 0.6666667, Recall 0.13333334, F1_score0.22222224                                                                              
[TrainSet] pass_id:999 pass_precision:[0.6666667] pass_recall:[0.13333334] pass_f1_score:[0.22222222]
[TestSet] pass_id:999 pass_precision:[1.] pass_recall:[0.0625] pass_f1_score:[0.11764706
```

What we get in Python2
```
[TestSet] pass_id:993 pass_precision:[0.] pass_recall:[0.] pass_f1_score:[0.]
[9.699361]
Pass 994, Batch 0, Cost 9.699361, Precision 0.6666667, Recall 0.13333334, F1_score0.22222224
[TrainSet] pass_id:994 pass_precision:[0.6666667] pass_recall:[0.13333334] pass_f1_score:[0.22222222]
[TestSet] pass_id:994 pass_precision:[0.] pass_recall:[0.] pass_f1_score:[0.]
[9.390462]
Pass 995, Batch 0, Cost 9.390462, Precision 0.6666667, Recall 0.13333334, F1_score0.22222224
[TrainSet] pass_id:995 pass_precision:[0.6666667] pass_recall:[0.13333334] pass_f1_score:[0.22222222]
[TestSet] pass_id:995 pass_precision:[0.] pass_recall:[0.] pass_f1_score:[0.]
[9.693841]
Pass 996, Batch 0, Cost 9.693841, Precision 0.6666667, Recall 0.13333334, F1_score0.22222224
[TrainSet] pass_id:996 pass_precision:[0.6666667] pass_recall:[0.13333334] pass_f1_score:[0.22222222]
[TestSet] pass_id:996 pass_precision:[0.] pass_recall:[0.] pass_f1_score:[0.]
[9.384099]
Pass 997, Batch 0, Cost 9.384099, Precision 0.6666667, Recall 0.13333334, F1_score0.22222224
[TrainSet] pass_id:997 pass_precision:[0.6666667] pass_recall:[0.13333334] pass_f1_score:[0.22222222]
[TestSet] pass_id:997 pass_precision:[0.] pass_recall:[0.] pass_f1_score:[0.]
[9.6883335]
Pass 998, Batch 0, Cost 9.6883335, Precision 0.6666667, Recall 0.13333334, F1_score0.22222224
[TrainSet] pass_id:998 pass_precision:[0.6666667] pass_recall:[0.13333334] pass_f1_score:[0.22222222]
[TestSet] pass_id:998 pass_precision:[0.] pass_recall:[0.] pass_f1_score:[0.]
[9.377722]
Pass 999, Batch 0, Cost 9.377722, Precision 0.6666667, Recall 0.13333334, F1_score0.22222224
[TrainSet] pass_id:999 pass_precision:[0.6666667] pass_recall:[0.13333334] pass_f1_score:[0.22222222]
[TestSet] pass_id:999 pass_precision:[0.] pass_recall:[0.] pass_f1_score:[0.]
```