### PR TITLE
Enblae CE.

### DIFF
--- a/fluid/image_classification/.run_ce.sh
+++ b/fluid/image_classification/.run_ce.sh
@@ -4,8 +4,8 @@
 export FLAGS_cudnn_deterministic=True
 cudaid=${object_detection_cudaid:=0}
 export CUDA_VISIBLE_DEVICES=$cudaid
-python train.py --batch_size=64 --num_epochs=10 --enable_ce=True | python _ce.py
+python train.py --batch_size=64 --num_epochs=5 --enable_ce=True --lr_strategy=cosine_decay | python _ce.py
 
 cudaid=${object_detection_cudaid_m:=0, 1, 2, 3}
 export CUDA_VISIBLE_DEVICES=$cudaid
-python train.py --batch_size=64 --num_epochs=10 --enable_ce=True | python _ce.py
+python train.py --batch_size=64 --num_epochs=5 --enable_ce=True --lr_strategy=cosine_decay | python _ce.py

--- a/fluid/image_classification/_ce.py
+++ b/fluid/image_classification/_ce.py
@@ -10,39 +10,39 @@ from kpi import CostKpi, DurationKpi, AccKpi
 #### NOTE kpi.py should shared in models in some way!!!!
 
 train_acc_top1_kpi = AccKpi(
-    'train_acc_top1', 0.05, 0, actived=False, desc='TOP1 ACC')
+    'train_acc_top1', 0.02, 0, actived=True, desc='TOP1 ACC')
 train_acc_top5_kpi = AccKpi(
-    'train_acc_top5', 0.05, 0, actived=False, desc='TOP5 ACC')
-train_cost_kpi = CostKpi('train_cost', 0.5, 0, actived=False, desc='train cost')
+    'train_acc_top5', 0.02, 0, actived=True, desc='TOP5 ACC')
+train_cost_kpi = CostKpi('train_cost', 0.02, 0, actived=True, desc='train cost')
 test_acc_top1_kpi = AccKpi(
-    'test_acc_top1', 0.05, 0, actived=False, desc='TOP1 ACC')
+    'test_acc_top1', 0.02, 0, actived=True, desc='TOP1 ACC')
 test_acc_top5_kpi = AccKpi(
-    'test_acc_top5', 0.05, 0, actived=False, desc='TOP5 ACC')
-test_cost_kpi = CostKpi('test_cost', 0.5, 0, actived=False, desc='train cost')
+    'test_acc_top5', 0.02, 0, actived=True, desc='TOP5 ACC')
+test_cost_kpi = CostKpi('test_cost', 0.02, 0, actived=True, desc='train cost')
 train_speed_kpi = AccKpi(
     'train_speed',
-    0.5,
+    0.05,
     0,
-    actived=False,
+    actived=True,
     unit_repr='seconds/image',
     desc='train speed in one GPU card')
 train_acc_top1_card4_kpi = AccKpi(
-    'train_acc_top1_card4', 0.05, 0, actived=False, desc='TOP1 ACC')
+    'train_acc_top1_card4', 0.02, 0, actived=True, desc='TOP1 ACC')
 train_acc_top5_card4_kpi = AccKpi(
-    'train_acc_top5_card4', 0.05, 0, actived=False, desc='TOP5 ACC')
+    'train_acc_top5_card4', 0.02, 0, actived=True, desc='TOP5 ACC')
 train_cost_card4_kpi = CostKpi(
-    'train_cost_card4', 0.5, 0, actived=False, desc='train cost')
+    'train_cost_card4', 0.02, 0, actived=True, desc='train cost')
 test_acc_top1_card4_kpi = AccKpi(
-    'test_acc_top1_card4', 0.05, 0, actived=False, desc='TOP1 ACC')
+    'test_acc_top1_card4', 0.02, 0, actived=True, desc='TOP1 ACC')
 test_acc_top5_card4_kpi = AccKpi(
-    'test_acc_top5_card4', 0.05, 0, actived=False, desc='TOP5 ACC')
+    'test_acc_top5_card4', 0.02, 0, actived=True, desc='TOP5 ACC')
 test_cost_card4_kpi = CostKpi(
-    'test_cost_card4', 0.5, 0, actived=False, desc='train cost')
+    'test_cost_card4', 0.02, 0, actived=True, desc='train cost')
 train_speed_card4_kpi = AccKpi(
     'train_speed_card4',
-    0.5,
+    0.05,
     0,
-    actived=False,
+    actived=True,
     unit_repr='seconds/image',
     desc='train speed in four GPU card')
 tracking_kpis = [

--- a/fluid/image_classification/models/se_resnext.py
+++ b/fluid/image_classification/models/se_resnext.py
@@ -14,7 +14,7 @@ train_parameters = {
     "input_size": [3, 224, 224],
     "input_mean": [0.485, 0.456, 0.406],
     "input_std": [0.229, 0.224, 0.225],
-    "enable_ce": False,
+    "dropout_seed": None,
     "learning_strategy": {
         "name": "piecewise_decay",
         "batch_size": 256,
@@ -105,11 +105,8 @@ class SE_ResNeXt():
 
         pool = fluid.layers.pool2d(
             input=conv, pool_size=7, pool_type='avg', global_pooling=True)
-        # enable_ce is used for continuous evaluation to remove the randomness
-        if self.params["enable_ce"]:
-            drop = pool
-        else:
-            drop = fluid.layers.dropout(x=pool, dropout_prob=0.5)
+        drop = fluid.layers.dropout(
+            x=pool, dropout_prob=0.5, seed=self.params['dropout_seed'])
         stdv = 1.0 / math.sqrt(drop.shape[1] * 1.0)
         out = fluid.layers.fc(input=drop,
                               size=class_dim,

--- a/fluid/image_classification/train.py
+++ b/fluid/image_classification/train.py
@@ -108,7 +108,7 @@ def train(args):
     if args.enable_ce:
         assert model_name == "SE_ResNeXt50_32x4d"
         fluid.default_startup_program().random_seed = 1000
-        model.params["enable_ce"] = True
+        model.params["dropout_seed"] = 100
         class_dim = 102
 
     if model_name == "GoogleNet":
@@ -269,21 +269,14 @@ def train(args):
                 print("kpis	train_speed	%s" % train_speed)
             else:
                 # Use the mean cost/acc for training
-                print("kpis	train_cost_card%s	%s" %
-                      (gpu_nums, train_loss))
-                print("kpis	train_acc_top1_card%s	%s" %
-                      (gpu_nums, train_acc1))
-                print("kpis	train_acc_top5_card%s	%s" %
-                      (gpu_nums, train_acc5))
+                print("kpis	train_cost_card%s	%s" % (gpu_nums, train_loss))
+                print("kpis	train_acc_top1_card%s	%s" % (gpu_nums, train_acc1))
+                print("kpis	train_acc_top5_card%s	%s" % (gpu_nums, train_acc5))
                 # Use the mean cost/acc for testing
-                print("kpis	test_cost_card%s	%s" %
-                      (gpu_nums, test_loss))
-                print("kpis	test_acc_top1_card%s	%s" %
-                      (gpu_nums, test_acc1))
-                print("kpis	test_acc_top5_card%s	%s" %
-                      (gpu_nums, test_acc5))
-                print("kpis	train_speed_card%s	%s" %
-                      (gpu_nums, train_speed))
+                print("kpis	test_cost_card%s	%s" % (gpu_nums, test_loss))
+                print("kpis	test_acc_top1_card%s	%s" % (gpu_nums, test_acc1))
+                print("kpis	test_acc_top5_card%s	%s" % (gpu_nums, test_acc5))
+                print("kpis	train_speed_card%s	%s" % (gpu_nums, train_speed))
 
 
 def main():


### PR DESCRIPTION
## 单卡：
- 第1次：
End pass 4, train_loss 2.12023425102, train_acc1 0.394168823957, train_acc5 0.760309278965, test_loss 3.61763519306, test_acc1 0.22450980398, test_acc5 0.520588235294
kpis    train_cost      2.1202343
kpis    train_acc_top1  0.39416882
kpis    train_acc_top5  0.7603093
kpis    test_cost       3.6176351930580886
kpis    test_acc_top1   0.22450980398000456
kpis    test_acc_top5   0.5205882352941177
kpis    train_speed     0.008752502078555295

- 第2次：
End pass 4, train_loss 2.12023425102, train_acc1 0.394168823957, train_acc5 0.760309278965, test_loss 3.61763519306, test_acc1 0.22450980398, test_acc5 0.520588235294
kpis    train_cost      2.1202343
kpis    train_acc_top1  0.39416882
kpis    train_acc_top5  0.7603093
kpis    test_cost       3.6176351930580886
kpis    test_acc_top1   0.22450980398000456
kpis    test_acc_top5   0.5205882352941177
kpis    train_speed     0.008734033817482978

-  第3次：
End pass 4, train_loss 2.12023425102, train_acc1 0.394168823957, train_acc5 0.760309278965, test_loss 3.61763519306, test_acc1 0.22450980398, test_acc5 0.520588235294
kpis    train_cost      2.1202343
kpis    train_acc_top1  0.39416882
kpis    train_acc_top5  0.7603093
kpis    test_cost       3.6176351930580886
kpis    test_acc_top1   0.22450980398000456
kpis    test_acc_top5   0.5205882352941177
kpis    train_speed     0.008762291296548451


## 4 GPU:

- 第1次：
End pass 4, train_loss 2.30516624451, train_acc1 0.372583776712, train_acc5 0.7156894207, test_loss 2.99038035262, test_acc1 0.250980392215, test_acc5 0.569607843605
kpis    train_cost_card4        2.3051662
kpis    train_acc_top1_card4    0.37258378
kpis    train_acc_top5_card4    0.7156894
kpis    test_cost_card4 2.9903803526186477
kpis    test_acc_top1_card4     0.25098039221529866
kpis    test_acc_top5_card4     0.5696078436047423
kpis    train_speed_card4       0.009354218879004115

- 第2次：
End pass 4, train_loss 2.30516624451, train_acc1 0.372583776712, train_acc5 0.7156894207, test_loss 2.99038035262, test_acc1 0.250980392215, test_acc5 0.569607843605
kpis    train_cost_card4        2.3051662
kpis    train_acc_top1_card4    0.37258378
kpis    train_acc_top5_card4    0.7156894
kpis    test_cost_card4 2.9903803526186477
kpis    test_acc_top1_card4     0.25098039221529866
kpis    test_acc_top5_card4     0.5696078436047423
kpis    train_speed_card4       0.008732693826722116

- 第3次：
End pass 4, train_loss 2.30516624451, train_acc1 0.372583776712, train_acc5 0.7156894207, test_loss 2.99038035262, test_acc1 0.250980392215, test_acc5 0.569607843605
kpis    train_cost_card4        2.3051662
kpis    train_acc_top1_card4    0.37258378
kpis    train_acc_top5_card4    0.7156894
kpis    test_cost_card4 2.9903803526186477
kpis    test_acc_top1_card4     0.25098039221529866
kpis    test_acc_top5_card4     0.5696078436047423
kpis    train_speed_card4       0.008874484520290316
