### PR TITLE
compatible for python3

### DIFF
--- a/fluid/faster_rcnn/profile.py
+++ b/fluid/faster_rcnn/profile.py
@@ -109,7 +109,7 @@ def train(cfg):
 
         for batch_id in range(iterations):
             start_time = time.time()
-            data = train_reader().next()
+            data = next(train_reader())
             end_time = time.time()
             reader_time.append(end_time - start_time)
             start_time = time.time()

--- a/fluid/faster_rcnn/roidbs.py
+++ b/fluid/faster_rcnn/roidbs.py
@@ -26,7 +26,6 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import copy
-import cPickle as pickle
 import logging
 import numpy as np
 import os


### PR DESCRIPTION
pickle isn't used in Faster RCNN 