### PR TITLE
Fix face_detection reader 'None' error

### DIFF
--- a/fluid/face_detection/data_util.py
+++ b/fluid/face_detection/data_util.py
@@ -9,6 +9,7 @@ import time
 import numpy as np
 import threading
 import multiprocessing
+import traceback
 try:
     import queue
 except ImportError:
@@ -71,6 +72,7 @@ class GeneratorEnqueuer(object):
                         try:
                             task()
                         except Exception:
+                            traceback.print_exc()
                             self._stop_event.set()
                             break
             else:
@@ -78,6 +80,7 @@ class GeneratorEnqueuer(object):
                     try:
                         task()
                     except Exception:
+                        traceback.print_exc()
                         self._stop_event.set()
                         break
 

--- a/fluid/face_detection/reader.py
+++ b/fluid/face_detection/reader.py
@@ -250,6 +250,10 @@ def train_generator(settings, file_list, batch_size, shuffle=True):
                     ymin = float(temp_info_box[1])
                     w = float(temp_info_box[2])
                     h = float(temp_info_box[3])
+
+                    # Filter out wrong labels
+                    if w < 0 or h < 0:
+                        continue
                     xmax = xmin + w
                     ymax = ymin + h
 
@@ -285,8 +289,7 @@ def train(settings,
         try:
             enqueuer = GeneratorEnqueuer(
                 train_generator(settings, file_list, batch_size, shuffle),
-                use_multiprocessing=use_multiprocessing,
-                wait_time=0.5)
+                use_multiprocessing=use_multiprocessing)
             enqueuer.start(max_queue_size=max_queue, workers=num_workers)
             generator_output = None
             while True:
@@ -295,7 +298,7 @@ def train(settings,
                         generator_output = enqueuer.queue.get()
                         break
                     else:
-                        time.sleep(0.5)
+                        time.sleep(0.01)
                 yield generator_output
                 generator_output = None
         finally:


### PR DESCRIPTION
Fix https://github.com/PaddlePaddle/models/issues/1245

WIDERFACE contains some wrong labels.
Some `w` or `h`< 0. This will result in a `data-anchor-sampling` error because the number below the square root is less than zero.
https://github.com/PaddlePaddle/models/blob/e2131fbc02f86720605aa79fd72720ecce24932a/fluid/face_detection/image_util.py#L147

So an if judgment is added to filter out the unqualified labels.