### PR TITLE
fix bug for machine_reading_comprehension in python3x

### DIFF
--- a/fluid/PaddleNLP/machine_reading_comprehension/dataset.py
+++ b/fluid/PaddleNLP/machine_reading_comprehension/dataset.py
@@ -67,7 +67,7 @@ class BRCDataset(object):
         Args:
             data_path: the data file to load
         """
-        with open(data_path) as fin:
+        with open(data_path, 'r', encoding='utf-8') as fin:
             data_set = []
             for lidx, line in enumerate(fin):
                 sample = json.loads(line.strip())

--- a/fluid/PaddleNLP/machine_reading_comprehension/dataset.py
+++ b/fluid/PaddleNLP/machine_reading_comprehension/dataset.py
@@ -23,6 +23,7 @@ import json
 import logging
 import numpy as np
 from collections import Counter
+import io
 
 
 class BRCDataset(object):
@@ -67,7 +68,7 @@ class BRCDataset(object):
         Args:
             data_path: the data file to load
         """
-        with open(data_path, 'r', encoding='utf-8') as fin:
+        with io.open(data_path, 'r', encoding='utf-8') as fin:
             data_set = []
             for lidx, line in enumerate(fin):
                 sample = json.loads(line.strip())

--- a/fluid/PaddleNLP/machine_reading_comprehension/run.py
+++ b/fluid/PaddleNLP/machine_reading_comprehension/run.py
@@ -22,6 +22,7 @@ import os
 import random
 import json
 import six
+import multiprocessing
 
 import paddle
 import paddle.fluid as fluid


### PR DESCRIPTION
1. dataset error: encode by utf-8
2. miss `import multiprocessing` for cpu train (run.py)