### PR TITLE
fix previous merge bug

### DIFF
--- a/fluid/PaddleCV/image_classification/models/alexnet.py
+++ b/fluid/PaddleCV/image_classification/models/alexnet.py
@@ -142,7 +142,6 @@ class AlexNet():
         out = fluid.layers.fc(
             input=fc7,
             size=class_dim,
-            act='softmax',
             bias_attr=fluid.param_attr.ParamAttr(
                 initializer=fluid.initializer.Uniform(-stdv, stdv)),
             param_attr=fluid.param_attr.ParamAttr(

--- a/fluid/PaddleCV/image_classification/models/dpn.py
+++ b/fluid/PaddleCV/image_classification/models/dpn.py
@@ -94,7 +94,6 @@ class DPN(object):
             initializer=fluid.initializer.Uniform(-stdv, stdv))
         fc6 = fluid.layers.fc(input=pool5,
                               size=class_dim,
-                              act='softmax',
                               param_attr=param_attr)
 
         return fc6

--- a/fluid/PaddleCV/image_classification/models/inception_v4.py
+++ b/fluid/PaddleCV/image_classification/models/inception_v4.py
@@ -47,7 +47,6 @@ class InceptionV4():
         out = fluid.layers.fc(
             input=drop,
             size=class_dim,
-            act='softmax',
             param_attr=fluid.param_attr.ParamAttr(
                 initializer=fluid.initializer.Uniform(-stdv, stdv)))
         return out

--- a/fluid/PaddleCV/image_classification/models/mobilenet.py
+++ b/fluid/PaddleCV/image_classification/models/mobilenet.py
@@ -120,7 +120,6 @@ class MobileNet():
 
         output = fluid.layers.fc(input=input,
                                  size=class_dim,
-                                 act='softmax',
                                  param_attr=ParamAttr(initializer=MSRA()))
         return output
 

--- a/fluid/PaddleCV/image_classification/models/mobilenet_v2.py
+++ b/fluid/PaddleCV/image_classification/models/mobilenet_v2.py
@@ -73,7 +73,6 @@ class MobileNetV2():
 
         output = fluid.layers.fc(input=input,
                                  size=class_dim,
-                                 act='softmax',
                                  param_attr=ParamAttr(initializer=MSRA()))
         return output
 

--- a/fluid/PaddleCV/image_classification/models/resnet.py
+++ b/fluid/PaddleCV/image_classification/models/resnet.py
@@ -60,7 +60,6 @@ class ResNet():
         stdv = 1.0 / math.sqrt(pool.shape[1] * 1.0)
         out = fluid.layers.fc(input=pool,
                               size=class_dim,
-                              act='softmax',
                               param_attr=fluid.param_attr.ParamAttr(
                                   initializer=fluid.initializer.Uniform(-stdv,
                                                                         stdv)))

--- a/fluid/PaddleCV/image_classification/models/resnet_dist.py
+++ b/fluid/PaddleCV/image_classification/models/resnet_dist.py
@@ -62,7 +62,6 @@ class DistResNet():
         stdv = 1.0 / math.sqrt(pool.shape[1] * 1.0)
         out = fluid.layers.fc(input=pool,
                               size=class_dim,
-                              act='softmax',
                               param_attr=fluid.param_attr.ParamAttr(
                                   initializer=fluid.initializer.Uniform(-stdv,
                                                                         stdv),

--- a/fluid/PaddleCV/image_classification/models/se_resnext.py
+++ b/fluid/PaddleCV/image_classification/models/se_resnext.py
@@ -110,7 +110,6 @@ class SE_ResNeXt():
         stdv = 1.0 / math.sqrt(drop.shape[1] * 1.0)
         out = fluid.layers.fc(input=drop,
                               size=class_dim,
-                              act='softmax',
                               param_attr=fluid.param_attr.ParamAttr(
                                   initializer=fluid.initializer.Uniform(-stdv,
                                                                         stdv)))

--- a/fluid/PaddleCV/image_classification/models/shufflenet_v2.py
+++ b/fluid/PaddleCV/image_classification/models/shufflenet_v2.py
@@ -93,7 +93,6 @@ class ShuffleNetV2():
 
         output = fluid.layers.fc(input=pool_last,
                                  size=class_dim,
-                                 act='softmax',
                                  param_attr=ParamAttr(initializer=MSRA()))
         return output
 

--- a/fluid/PaddleCV/image_classification/models/vgg.py
+++ b/fluid/PaddleCV/image_classification/models/vgg.py
@@ -64,7 +64,6 @@ class VGGNet():
         out = fluid.layers.fc(
             input=fc2,
             size=class_dim,
-            act='softmax',
             param_attr=fluid.param_attr.ParamAttr(
                 initializer=fluid.initializer.Normal(scale=0.005)),
             bias_attr=fluid.param_attr.ParamAttr(

--- a/fluid/PaddleCV/image_classification/models_name/alexnet.py
+++ b/fluid/PaddleCV/image_classification/models_name/alexnet.py
@@ -159,7 +159,6 @@ class AlexNet():
         out = fluid.layers.fc(
             input=fc7,
             size=class_dim,
-            act='softmax',
             bias_attr=fluid.param_attr.ParamAttr(
                 initializer=fluid.initializer.Uniform(-stdv, stdv),
                 name=layer_name[7] + "_offset"),

--- a/fluid/PaddleCV/image_classification/models_name/dpn.py
+++ b/fluid/PaddleCV/image_classification/models_name/dpn.py
@@ -122,7 +122,6 @@ class DPN(object):
             initializer=fluid.initializer.Uniform(-stdv, stdv))
         fc6 = fluid.layers.fc(input=pool5,
                               size=class_dim,
-                              act='softmax',
                               param_attr=param_attr,
                               name="fc6")
 

--- a/fluid/PaddleCV/image_classification/models_name/inception_v4.py
+++ b/fluid/PaddleCV/image_classification/models_name/inception_v4.py
@@ -48,7 +48,6 @@ class InceptionV4():
         out = fluid.layers.fc(
             input=drop,
             size=class_dim,
-            act='softmax',
             param_attr=ParamAttr(
                 initializer=fluid.initializer.Uniform(-stdv, stdv),
                 name="final_fc_weights"),

--- a/fluid/PaddleCV/image_classification/models_name/mobilenet.py
+++ b/fluid/PaddleCV/image_classification/models_name/mobilenet.py
@@ -130,7 +130,6 @@ class MobileNet():
 
         output = fluid.layers.fc(input=input,
                                  size=class_dim,
-                                 act='softmax',
                                  param_attr=ParamAttr(
                                      initializer=MSRA(), name="fc7_weights"),
                                  bias_attr=ParamAttr(name="fc7_offset"))

--- a/fluid/PaddleCV/image_classification/models_name/mobilenet_v2.py
+++ b/fluid/PaddleCV/image_classification/models_name/mobilenet_v2.py
@@ -80,7 +80,6 @@ class MobileNetV2():
 
         output = fluid.layers.fc(input=input,
                                  size=class_dim,
-                                 act='softmax',
                                  param_attr=ParamAttr(name='fc10_weights'),
                                  bias_attr=ParamAttr(name='fc10_offset'))
         return output

--- a/fluid/PaddleCV/image_classification/models_name/resnet.py
+++ b/fluid/PaddleCV/image_classification/models_name/resnet.py
@@ -74,7 +74,6 @@ class ResNet():
         stdv = 1.0 / math.sqrt(pool.shape[1] * 1.0)
         out = fluid.layers.fc(input=pool,
                               size=class_dim,
-                              act='softmax',
                               param_attr=fluid.param_attr.ParamAttr(
                                   initializer=fluid.initializer.Uniform(-stdv,
                                                                         stdv)))

--- a/fluid/PaddleCV/image_classification/models_name/se_resnext.py
+++ b/fluid/PaddleCV/image_classification/models_name/se_resnext.py
@@ -123,7 +123,6 @@ class SE_ResNeXt():
         out = fluid.layers.fc(
             input=drop,
             size=class_dim,
-            act='softmax',
             param_attr=ParamAttr(
                 initializer=fluid.initializer.Uniform(-stdv, stdv),
                 name='fc6_weights'),

--- a/fluid/PaddleCV/image_classification/models_name/shufflenet_v2.py
+++ b/fluid/PaddleCV/image_classification/models_name/shufflenet_v2.py
@@ -97,7 +97,6 @@ class ShuffleNetV2():
 
         output = fluid.layers.fc(input=pool_last,
                                  size=class_dim,
-                                 act='softmax',
                                  param_attr=ParamAttr(
                                      initializer=MSRA(), name='fc6_weights'),
                                  bias_attr=ParamAttr(name='fc6_offset'))

--- a/fluid/PaddleCV/image_classification/models_name/vgg.py
+++ b/fluid/PaddleCV/image_classification/models_name/vgg.py
@@ -61,7 +61,6 @@ class VGGNet():
         out = fluid.layers.fc(
             input=fc2,
             size=class_dim,
-            act='softmax',
             param_attr=fluid.param_attr.ParamAttr(name=fc_name[2] + "_weights"),
             bias_attr=fluid.param_attr.ParamAttr(name=fc_name[2] + "_offset"))
 


### PR DESCRIPTION
Since we use `softmax_with_cross_entropy` in train.py, need to remove fc output softmax activations

Fix changes from https://github.com/PaddlePaddle/models/pull/1533