### PR TITLE
 Add judgment when draw box

### DIFF
--- a/PaddleCV/rcnn/eval_helper.py
+++ b/PaddleCV/rcnn/eval_helper.py
@@ -230,6 +230,9 @@ def draw_mask_on_image(image_path, segms_out, draw_threshold, alpha=0.7):
     w_ratio = .4
     image = np.array(image).astype('float32')
     for dt in np.array(segms_out):
+        if dt.shape[0]!=6:
+            print("image {} has not bbox!".format(image_name))
+            continue
         segm, num_id, score = dt.tolist()
         if score < draw_threshold:
             continue

--- a/PaddleCV/rcnn/roidbs.py
+++ b/PaddleCV/rcnn/roidbs.py
@@ -60,6 +60,7 @@ class JsonDataset(object):
         categories = [c['name'] for c in self.COCO.loadCats(category_ids)]
         self.category_to_id_map = dict(zip(categories, category_ids))
         self.classes = ['__background__'] + categories
+        assert len(self.classes) == cfg.class_num, "The class_num in config is wrong!"
         self.num_classes = len(self.classes)
         self.json_category_id_to_contiguous_id = {
             v: i + 1

--- a/PaddleCV/yolov3/weights/download.sh
+++ b/PaddleCV/yolov3/weights/download.sh
@@ -3,8 +3,8 @@ cd "$DIR"
 
 # Download the pretrain weights.
 echo "Downloading..."
-wget https://paddlemodels.bj.bcebos.com/yolo/darknet53.tar.gz
-wget https://paddlemodels.bj.bcebos.com/yolo/yolov3.tar.gz
+wget https://paddlemodels.bj.bcebos.com/yolo/darknet53.tar.gz --no-check-certificate
+wget https://paddlemodels.bj.bcebos.com/yolo/yolov3.tar.gz --no-check-certificate
 echo "Extracting..."
 tar -xf darknet53.tar.gz
 tar -xf yolov3.tar.gz


### PR DESCRIPTION
当图像中没有bounding box时，执行draw_mask_on_image函数中的”num_id, score, xmin, ymin, xmax, ymax = dt.tolist()“会出现”ValueError: not enough values to unpack (expected 6, got 1)“的错误，所以需要加入判断。