### PR TITLE
fix yolo python3 compatible.

### DIFF
--- a/PaddleCV/yolov3/eval.py
+++ b/PaddleCV/yolov3/eval.py
@@ -68,7 +68,7 @@ def eval():
             res = {
                     'image_id': im_id,
                     'category_id': label_ids[int(label)],
-                    'bbox': map(float, bbox),
+                    'bbox': list(map(float, bbox)),
                     'score': float(score)
             }
             result.append(res)


### PR DESCRIPTION
python3下map函数表现与python2不同，通过list触发计算
fix https://github.com/PaddlePaddle/models/issues/2075