### PR TITLE
mem_opt for yolov3.

### DIFF
--- a/PaddleCV/yolov3/train.py
+++ b/PaddleCV/yolov3/train.py
@@ -80,9 +80,11 @@ def train():
             return os.path.exists(os.path.join(cfg.pretrain, var.name))
         fluid.io.load_vars(exe, cfg.pretrain, predicate=if_exist)
 
+    build_strategy= fluid.BuildStrategy()
+    build_strategy.memory_optimize = True
     compile_program = fluid.compiler.CompiledProgram(
             fluid.default_main_program()).with_data_parallel(
-            loss_name=loss.name)
+            loss_name=loss.name, build_strategy=build_strategy)
 
     random_sizes = [cfg.input_size]
     if cfg.random_shape:


### PR DESCRIPTION
1.4 版本默认不开启mem_opt，在代码里开启
fix https://github.com/PaddlePaddle/models/issues/2089