### PR TITLE
Add a note in image classification to remind users to replace PE to exec 

### DIFF
--- a/PaddleCV/image_classification/README.md
+++ b/PaddleCV/image_classification/README.md
@@ -16,6 +16,8 @@ Image classification, which is an important field of computer vision, is to clas
 
 Running sample code in this directory requires PaddelPaddle Fluid v0.13.0 and later, the latest release version is recommended, If the PaddlePaddle on your device is lower than v0.13.0, please follow the instructions in [installation document](http://paddlepaddle.org/documentation/docs/zh/1.3/beginners_guide/install/index_cn.html) and make an update.
 
+Note: Please replace [fluid.ParallelExecutor](http://paddlepaddle.org/documentation/docs/zh/1.4/api_cn/fluid_cn.html#parallelexecutor) to [fluid.Executor](http://paddlepaddle.org/documentation/docs/zh/1.4/api_cn/fluid_cn.html#executor) when running the program in the windows & GPU environment.
+
 ## Data preparation
 
 An example for ImageNet classification is as follows. First of all, preparation of imagenet data can be done as:

--- a/PaddleCV/image_classification/README_cn.md
+++ b/PaddleCV/image_classification/README_cn.md
@@ -16,6 +16,8 @@
 
 在当前目录下运行样例代码需要PadddlePaddle Fluid的v0.13.0或以上的版本。如果你的运行环境中的PaddlePaddle低于此版本，请根据 [installation document](http://paddlepaddle.org/documentation/docs/zh/1.3/beginners_guide/install/index_cn.html) 中的说明来更新PaddlePaddle。
 
+注意：由于windows不支持nccl，当使用Windows GPU环境时候，需要将示例代码中的[fluid.ParallelExecutor](http://paddlepaddle.org/documentation/docs/zh/1.4/api_cn/fluid_cn.html#parallelexecutor)替换为[fluid.Executor](http://paddlepaddle.org/documentation/docs/zh/1.4/api_cn/fluid_cn.html#executor)。
+
 ## 数据准备
 
 下面给出了ImageNet分类任务的样例，首先，通过如下的方式进行数据的准备：


### PR DESCRIPTION
Because WINDOWS does not support NCCL. It will raise an error when users try to run the multi-GPUs program on WINDOWS machine. So add a note to remind users to replace parallel executor to executor.