### PR TITLE
Refine PE doc in rcnn for Windows users

### DIFF
--- a/PaddleCV/rcnn/README.md
+++ b/PaddleCV/rcnn/README.md
@@ -104,6 +104,7 @@ After data preparation, one can start the training step by:
 
     - Set ```export CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7``` to specifiy 8 GPU to train.
     - Set ```MASK_ON``` to choose Faster RCNN or Mask RCNN model.
+    - Set ```parallel``` to False to replace [fluid.ParallelExecutor](http://paddlepaddle.org/documentation/docs/zh/1.4/api_cn/fluid_cn.html#parallelexecutor) to [fluid.Executor](http://paddlepaddle.org/documentation/docs/zh/1.4/api_cn/fluid_cn.html#executor) when running the program in the Windows & GPU environment.
     - For more help on arguments:
 
         python train.py --help

--- a/PaddleCV/rcnn/README_cn.md
+++ b/PaddleCV/rcnn/README_cn.md
@@ -105,6 +105,7 @@ data/coco/
 
     - 通过设置export CUDA\_VISIBLE\_DEVICES=0,1,2,3,4,5,6,7指定8卡GPU训练。
     - 通过设置```MASK_ON```选择Faster RCNN和Mask RCNN模型。
+    - 使用Windows GPU环境的用户，需要设置```parallel```为False，将[fluid.ParallelExecutor](http://paddlepaddle.org/documentation/docs/zh/1.4/api_cn/fluid_cn.html#parallelexecutor)替换为[fluid.Executor](http://paddlepaddle.org/documentation/docs/zh/1.4/api_cn/fluid_cn.html#executor)。
     - 可选参数见：
 
         python train.py --help


### PR DESCRIPTION
Because WINDOWS does not support NCCL. It will raise an error when users use parallel executor on WINDOWS machine. So add a note to remind users to replace parallel executor to executor.