### PR TITLE
fix video train param name epoch.

### DIFF
--- a/PaddleCV/video/scripts/train/train_attention_cluster.sh
+++ b/PaddleCV/video/scripts/train/train_attention_cluster.sh
@@ -1,3 +1,3 @@
 export CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7
-python train.py --model_name="AttentionCluster" --config=./configs/attention_cluster.txt --epoch_num=5 \
+python train.py --model_name="AttentionCluster" --config=./configs/attention_cluster.txt --epoch=5 \
                 --valid_interval=1 --log_interval=10

--- a/PaddleCV/video/scripts/train/train_attention_lstm.sh
+++ b/PaddleCV/video/scripts/train/train_attention_lstm.sh
@@ -1,3 +1,3 @@
 export CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7
-python train.py --model_name="AttentionLSTM" --config=./configs/attention_lstm.txt --epoch_num=10 \
+python train.py --model_name="AttentionLSTM" --config=./configs/attention_lstm.txt --epoch=10 \
                 --valid_interval=1 --log_interval=10

--- a/PaddleCV/video/scripts/train/train_nextvlad.sh
+++ b/PaddleCV/video/scripts/train/train_nextvlad.sh
@@ -1,3 +1,3 @@
 export CUDA_VISIBLE_DEVICES=0,1,2,3
-python train.py --model_name="NEXTVLAD" --config=./configs/nextvlad.txt --epoch_num=6 \
+python train.py --model_name="NEXTVLAD" --config=./configs/nextvlad.txt --epoch=6 \
                 --valid_interval=1 --log_interval=10

--- a/PaddleCV/video/scripts/train/train_nonlocal.sh
+++ b/PaddleCV/video/scripts/train/train_nonlocal.sh
@@ -1,3 +1,3 @@
-python train.py --model_name="NONLOCAL" --config=./configs/nonlocal.txt --epoch_num=120 \
+python train.py --model_name="NONLOCAL" --config=./configs/nonlocal.txt --epoch=120 \
                 --valid_interval=1 --log_interval=1 \
                 --pretrain=./pretrained/ResNet50_pretrained

--- a/PaddleCV/video/scripts/train/train_stnet.sh
+++ b/PaddleCV/video/scripts/train/train_stnet.sh
@@ -1,3 +1,3 @@
 export CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7
-python train.py --model_name="STNET" --config=./configs/stnet.txt --epoch_num=60 \
+python train.py --model_name="STNET" --config=./configs/stnet.txt --epoch=60 \
                 --valid_interval=1 --log_interval=10

--- a/PaddleCV/video/scripts/train/train_tsm.sh
+++ b/PaddleCV/video/scripts/train/train_tsm.sh
@@ -5,5 +5,5 @@ export FLAGS_fast_eager_deletion_mode=1
 export FLAGS_eager_delete_tensor_gb=0.0
 export FLAGS_fraction_of_gpu_memory_to_use=0.98
 
-python train.py --model_name="TSM" --config=./configs/tsm.txt --epoch_num=65 \
+python train.py --model_name="TSM" --config=./configs/tsm.txt --epoch=65 \
                 --valid_interval=1 --log_interval=10

--- a/PaddleCV/video/scripts/train/train_tsn.sh
+++ b/PaddleCV/video/scripts/train/train_tsn.sh
@@ -1,3 +1,3 @@
 export CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7
-python train.py --model_name="TSN" --config=./configs/tsn.txt --epoch_num=45 \
+python train.py --model_name="TSN" --config=./configs/tsn.txt --epoch=45 \
                 --valid_interval=1 --log_interval=10

--- a/PaddleCV/video/train.py
+++ b/PaddleCV/video/train.py
@@ -79,7 +79,7 @@ def parse_args():
         default=False,
         help='whether to use memory optimize in train')
     parser.add_argument(
-        '--epoch_num',
+        '--epoch',
         type=int,
         default=0,
         help='epoch number, 0 for read from config file')
@@ -197,7 +197,7 @@ def train(args):
     valid_fetch_list = [valid_loss.name] + [x.name for x in valid_outputs
                                             ] + [valid_feeds[-1].name]
 
-    epochs = args.epoch_num or train_model.epoch_num()
+    epochs = args.epoch or train_model.epoch_num()
 
     if args.no_use_pyreader:
         train_feeder = fluid.DataFeeder(place=place, feed_list=train_feeds)


### PR DESCRIPTION
fix for:
更改参数值后，log显示不变，例如在train_tsm.sh中更改epoch值为1后，log中显示的仍未
<img width="536" alt="57683613-a3e5d100-7666-11e9-992f-5abd25c40dc1" src="https://user-images.githubusercontent.com/12605721/57853663-e51de280-7818-11e9-83ba-cd9934aaa3f0.png">


为train中epoch_num参数与配置文件中epoch配置项命名不一致导致