### PR TITLE
fix error while loading cv2.VideoCapture

### DIFF
--- a/PaddleCV/video/datareader/kinetics_reader.py
+++ b/PaddleCV/video/datareader/kinetics_reader.py
@@ -417,7 +417,7 @@ def mp4_loader(filepath, nsample, seglen, mode):
                 idx = i
 
         for jj in range(idx, idx + seglen):
-            imgbuf = sampledFrames[int(jj % sampledFrames)]
+            imgbuf = sampledFrames[int(jj % len(sampledFrames))]
             img = Image.fromarray(imgbuf, mode='RGB')
             imgs.append(img)
 

--- a/PaddleCV/video/datareader/kinetics_reader.py
+++ b/PaddleCV/video/datareader/kinetics_reader.py
@@ -14,6 +14,7 @@
 
 import os
 import sys
+import cv2
 import math
 import random
 import functools

--- a/PaddleCV/video/datareader/kinetics_reader.py
+++ b/PaddleCV/video/datareader/kinetics_reader.py
@@ -387,7 +387,6 @@ def video_loader(frames, nsample, seglen, mode):
 def mp4_loader(filepath, nsample, seglen, mode):
     cap = cv2.VideoCapture(filepath)
     videolen = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
-    average_dur = int(videolen / nsample)
     sampledFrames = []
     for i in range(videolen):
         ret, frame = cap.read()
@@ -396,7 +395,7 @@ def mp4_loader(filepath, nsample, seglen, mode):
             continue
         img = frame[:, :, ::-1]
         sampledFrames.append(img)
-
+    average_dur = int(len(sampledFrames) / nsample)
     imgs = []
     for i in range(nsample):
         idx = 0
@@ -418,7 +417,7 @@ def mp4_loader(filepath, nsample, seglen, mode):
                 idx = i
 
         for jj in range(idx, idx + seglen):
-            imgbuf = sampledFrames[int(jj % videolen)]
+            imgbuf = sampledFrames[int(jj % sampledFrames)]
             img = Image.fromarray(imgbuf, mode='RGB')
             imgs.append(img)
 


### PR DESCRIPTION
1、fix error which cv2 is used but not import while loading mp4 file
2、while loading mp4 file, some frames may fail to be read and it may result in out of range in sampledFrames
![image](https://user-images.githubusercontent.com/17508662/58763991-ac119c00-8594-11e9-8a89-944be54b9346.png)
