### PR TITLE
init rcnn mixed precision training

### DIFF
--- a/PaddleCV/rcnn/config.py
+++ b/PaddleCV/rcnn/config.py
@@ -171,6 +171,27 @@ _C.dim_reduced = 256
 # Threshold for converting soft masks to hard masks
 _C.mrcnn_thresh_binarize = 0.5
 
+# Whether to use mixed precision training
+_C.use_fp16 = False
+
+# Loss scaling for mixed precision training
+_C.loss_scaling = 128.0
+
+# Increases loss scaling every n consecutive steps with finite gradients
+_C.incr_every_n_steps = 10000
+
+# Decreases loss scaling every n accumulated steps with nan or inf gradients
+_C.decr_every_n_nan_or_inf = 2
+
+# The multiplier to use when increasing the loss scaling
+_C.incr_ratio = 2.0
+
+# The less-than-one-multiplier to use when decreasing the loss scaling
+_C.decr_ratio = 0.8
+
+# Whether to use dynamic loss scaling
+_C.use_dynamic_loss_scaling = False
+
 #
 # SOLVER options
 #

--- a/PaddleCV/rcnn/models/load_model.py
+++ b/PaddleCV/rcnn/models/load_model.py
@@ -1,0 +1,95 @@
+import os
+from paddle.fluid import layers
+import paddle.fluid.core as core
+from paddle.fluid.executor import Executor
+from paddle.fluid.evaluator import Evaluator
+from paddle.fluid.framework import Program, Parameter, default_main_program, default_startup_program, Variable, program_guard
+
+def _clone_var_in_block_(block, var, name, dtype):
+    assert isinstance(var, Variable)
+    return block.create_var(
+        name=name,
+        shape=var.shape,
+        dtype=dtype,
+        type=var.type,
+        lod_level=var.lod_level,
+        persistable=True)
+
+def load_vars(executor,
+              dirname,
+              main_program=None,
+              vars=None,
+              predicate=None,
+              filename=None):
+    
+    load_dirname = os.path.normpath(dirname)
+    if vars is None:
+        if main_program is None:
+            main_program = default_main_program()
+        if not isinstance(main_program, Program):
+            raise TypeError("program's type should be Program")
+
+        load_vars(
+            executor,
+            dirname=load_dirname,
+            main_program=main_program,
+            vars=list(filter(predicate, main_program.list_vars())),
+            filename=filename)
+    else:
+        load_prog = Program()
+        load_block = load_prog.global_block()
+
+        if main_program is None:
+            main_program = default_main_program()
+        if not isinstance(main_program, Program):
+            raise TypeError("program should be as Program type or None")
+
+        load_var_map = {}
+        for each_var in vars:
+            assert isinstance(each_var, Variable)
+            if each_var.type == core.VarDesc.VarType.RAW:
+                continue
+            new_var = _clone_var_in_block_(load_block, each_var, each_var.name, each_var.dtype)
+            if filename is None:
+                if new_var.dtype == core.VarDesc.VarType.FP16:
+                    new_var_master = _clone_var_in_block_(load_block,
+                                                          each_var,
+                                                          each_var.name+'.master',
+                                                          core.VarDesc.VarType.FP32)
+                    load_block.append_op(
+                        type='load',
+                        inputs={},
+                        outputs={'Out': [new_var]},
+                        attrs={
+                            'file_path': os.path.join(load_dirname, new_var.name),
+                            'load_as_fp16': True
+                        })
+                    load_block.append_op(
+                        type='load',
+                        inputs={},
+                        outputs={'Out': [new_var_master]},
+                        attrs={
+                            'file_path': os.path.join(load_dirname, new_var.name),
+                        })
+                else:
+                    load_block.append_op(
+                        type='load',
+                        inputs={},
+                        outputs={'Out': [new_var]},
+                        attrs={
+                            'file_path': os.path.join(load_dirname, new_var.name)
+                        })
+            else:
+                load_var_map[new_var.name] = new_var
+
+        if filename is not None:
+            load_var_list = []
+            for name in sorted(load_var_map.keys()):
+                load_var_list.append(load_var_map[name])
+
+            load_block.append_op(
+                type='load_combine',
+                inputs={},
+                outputs={"Out": load_var_list},
+                attrs={'file_path': os.path.join(load_dirname, filename)})
+        executor.run(load_prog)

--- a/PaddleCV/rcnn/utility.py
+++ b/PaddleCV/rcnn/utility.py
@@ -158,6 +158,13 @@ def parse_args():
     add_arg('nms_thresh',    float, 0.5,    "NMS threshold.")
     add_arg('score_thresh',    float, 0.05,    "score threshold for NMS.")
     add_arg('snapshot_stride',  int,    10000,    "save model every snapshot stride.")
+    add_arg('use_fp16', bool, False, "Option for using mixed precision training.")
+    add_arg('use_dynamic_loss_scaling', bool, False, "Option for using auto loss scaling in mixed precision training. If True, loss scaling will change during training. If False, loss scaling is fixed.")
+    add_arg('loss_scaling', float, 128.0, "Loss scaling for mixed precision training.")
+    add_arg('incr_every_n_steps', int, 10000, "The number of steps to increase loss scaling.")
+    add_arg('decr_every_n_nan_or_inf', int, 2, "The number of steps to decrease loss scaling.")
+    add_arg('incr_ratio', float, 2.0, "The multiplier to use when increasing the loss scaling.")
+    add_arg('decr_ratio', float, 0.8, "The less-than-one-multiplier to use when decreasing the loss scaling.")
     # SINGLE EVAL AND DRAW
     add_arg('draw_threshold',  float, 0.8,    "Confidence threshold to draw bbox.")
     add_arg('image_path',       str,   'dataset/coco/val2017',  "The image path used to inference and visualize.")


### PR DESCRIPTION
This feature implements mixed precision training on rcnn. It utilizes auto loss scaling, black white lists to make training stable. 
Testing this feature requires this [pull request](https://github.com/PaddlePaddle/Paddle/pull/17847) in Paddle and turns on `--use_fp16=True` and `use_dynamic_loss_scaling=True`. You can also set `--loss_scaling`, `--incr_every_n_steps`, `--decr_every_n_nan_or_inf`, `--incr_ratio`, `--decr_ratio` to control the detail.