### PR TITLE
Update the optimization of PaddingRNN model in benchmark repo to models

### DIFF
--- a/PaddleNLP/language_model/args.py
+++ b/PaddleNLP/language_model/args.py
@@ -20,6 +20,15 @@ import argparse
 import distutils.util
 
 
+def str2bool(v):
+    if v.lower() in ('yes', 'true', 't', 'y', '1'):
+        return True
+    elif v.lower() in ('no', 'false', 'f', 'n', '0'):
+        return False
+    else:
+        raise argparse.ArgumentTypeError('Unsupported value encountered.')
+
+
 def parse_args():
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
@@ -36,10 +45,25 @@ def parse_args():
         "--data_path", type=str, help="all the data for train,valid,test")
     parser.add_argument('--para_init', action='store_true')
     parser.add_argument(
-        '--use_gpu', type=bool, default=False, help='whether using gpu')
+        '--use_gpu',
+        type=str2bool,
+        default=False,
+        help='Whether using gpu [True|False]')
+    parser.add_argument(
+        '--parallel',
+        type=str2bool,
+        default=True,
+        help='Whether using gpu in parallel [True|False]')
+    parser.add_argument(
+        '--use_py_reader',
+        type=str2bool,
+        default=False,
+        help='Whether using py_reader to feed data [True|False]')
     parser.add_argument(
         '--log_path',
         help='path of the log file. If not set, logs are printed to console')
     parser.add_argument('--enable_ce', action='store_true')
+    parser.add_argument('--batch_size', type=int, default=0, help='batch size')
+    parser.add_argument('--max_epoch', type=int, default=0, help='max epoch')
     args = parser.parse_args()
     return args

--- a/PaddleNLP/language_model/args.py
+++ b/PaddleNLP/language_model/args.py
@@ -62,6 +62,11 @@ def parse_args():
     parser.add_argument(
         '--log_path',
         help='path of the log file. If not set, logs are printed to console')
+    parser.add_argument(
+        '--save_model_dir',
+        type=str,
+        default="models",
+        help='dir of the saved model.')
     parser.add_argument('--enable_ce', action='store_true')
     parser.add_argument('--batch_size', type=int, default=0, help='batch size')
     parser.add_argument('--max_epoch', type=int, default=0, help='max epoch')

--- a/PaddleNLP/language_model/config.py
+++ b/PaddleNLP/language_model/config.py
@@ -70,6 +70,9 @@ class RNNConfig(object):
         else:
             raise ValueError('Unsupported model_type.')
 
+        if args.rnn_model not in ('static', 'padding', 'cudnn'):
+            raise ValueError('Unsupported rnn_model.')
+
         if args.batch_size > 0:
             self.batch_size = args.batch_size
 

--- a/PaddleNLP/language_model/config.py
+++ b/PaddleNLP/language_model/config.py
@@ -1,0 +1,77 @@
+#   Copyright (c) 2018 PaddlePaddle Authors. All Rights Reserve.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+class RNNConfig(object):
+    def __init__(self, args):
+        self.model_type = args.model_type
+        self.rnn_model = args.rnn_model
+
+        self.vocab_size = 10000
+        if self.model_type == "test":
+            self.num_layers = 1
+            self.batch_size = 2
+            self.hidden_size = 10
+            self.num_steps = 3
+            self.init_scale = 0.1
+            self.max_grad_norm = 5.0
+            self.epoch_start_decay = 1
+            self.max_epoch = 1
+            self.dropout = 0.0
+            self.lr_decay = 0.5
+            self.base_learning_rate = 1.0
+        elif self.model_type == "small":
+            self.num_layers = 2
+            self.batch_size = 20
+            self.hidden_size = 200
+            self.num_steps = 20
+            self.init_scale = 0.1
+            self.max_grad_norm = 5.0
+            self.epoch_start_decay = 4
+            self.max_epoch = 13
+            self.dropout = 0.0
+            self.lr_decay = 0.5
+            self.base_learning_rate = 1.0
+        elif self.model_type == "medium":
+            self.num_layers = 2
+            self.batch_size = 20
+            self.hidden_size = 650
+            self.num_steps = 35
+            self.init_scale = 0.05
+            self.max_grad_norm = 5.0
+            self.epoch_start_decay = 6
+            self.max_epoch = 39
+            self.dropout = 0.5
+            self.lr_decay = 0.8
+            self.base_learning_rate = 1.0
+        elif self.model_type == "large":
+            self.num_layers = 2
+            self.batch_size = 20
+            self.hidden_size = 1500
+            self.num_steps = 35
+            self.init_scale = 0.04
+            self.max_grad_norm = 10.0
+            self.epoch_start_decay = 14
+            self.max_epoch = 55
+            self.dropout = 0.65
+            self.lr_decay = 1.0 / 1.15
+            self.base_learning_rate = 1.0
+        else:
+            raise ValueError('Unsupported model_type.')
+
+        if args.batch_size > 0:
+            self.batch_size = args.batch_size
+
+        if args.max_epoch > 0:
+            self.max_epoch = args.max_epoch

--- a/PaddleNLP/language_model/train.py
+++ b/PaddleNLP/language_model/train.py
@@ -159,7 +159,6 @@ def main():
 
     exec_strategy = fluid.ExecutionStrategy()
     exec_strategy.num_threads = device_count
-    exec_strategy.use_experimental_executor = False
     exec_strategy.num_iteration_per_drop_scope = 100
 
     build_strategy = fluid.BuildStrategy()
@@ -194,10 +193,7 @@ def main():
     def generate_new_lr(epoch_id=0, device_count=1):
         new_lr = config.base_learning_rate * (config.lr_decay**max(
             epoch_id + 1 - config.epoch_start_decay, 0.0))
-        if device_count > 1 and args.parallel:
-            lr = np.ones((device_count), dtype='float32') * new_lr
-        else:
-            lr = np.ones((1), dtype='float32') * new_lr
+        lr = np.ones((device_count), dtype='float32') * new_lr
         return lr
 
     def prepare_input(batch,

--- a/PaddleNLP/language_model/train.py
+++ b/PaddleNLP/language_model/train.py
@@ -147,6 +147,9 @@ def main():
                 dropout=config.dropout,
                 rnn_model=config.rnn_model,
                 use_py_reader=False)
+    # Some op behaves differently for train and inference, we need to call
+    # this clone function to ensure every op is right for inference.
+    inference_program = inference_program.clone(for_test=True)
 
     place = fluid.CUDAPlace(0) if args.use_gpu else fluid.CPUPlace()
     exe = Executor(place)

--- a/PaddleNLP/language_model/train.py
+++ b/PaddleNLP/language_model/train.py
@@ -155,7 +155,8 @@ def main():
     exe = Executor(place)
     exe.run(startup_program)
 
-    device_count = fluid.core.get_cuda_device_count()
+    device_count = len(fluid.cuda_places()) if args.use_gpu else len(
+        fluid.cpu_places())
 
     exec_strategy = fluid.ExecutionStrategy()
     exec_strategy.num_threads = device_count

--- a/PaddleNLP/language_model/train.py
+++ b/PaddleNLP/language_model/train.py
@@ -162,9 +162,6 @@ def main():
     build_strategy = fluid.BuildStrategy()
     build_strategy.enable_inplace = True
     build_strategy.memory_optimize = False
-    build_strategy.remove_unnecessary_lock = True
-    build_strategy.enable_sequential_execution = False
-    build_strategy.cache_runtime_context = True
     build_strategy.fuse_all_optimizer_ops = True
 
     if args.parallel:
@@ -238,11 +235,11 @@ def main():
                 fetch_list=[loss.name, last_hidden.name, last_cell.name],
                 use_program_cache=True)
 
-            cost_train = np.array(fetch_outs[0])
+            cost_eval = np.array(fetch_outs[0])
             init_hidden = np.array(fetch_outs[1])
             init_cell = np.array(fetch_outs[2])
 
-            total_loss += cost_train
+            total_loss += cost_eval
             iters += config.num_steps
 
         ppl = np.exp(total_loss / iters)

--- a/PaddleNLP/language_model/train.py
+++ b/PaddleNLP/language_model/train.py
@@ -41,6 +41,7 @@ os.environ["TF_CPP_MIN_LOG_LEVEL"] = "3"
 from args import *
 sys.path.append("../")
 from models.language_model import lm_model
+from config import RNNConfig
 import logging
 import pickle
 
@@ -76,14 +77,10 @@ def save_para_npz(train_prog, train_exe):
 
 def main():
     args = parse_args()
-    model_type = args.model_type
-    rnn_model = args.rnn_model
     logger = logging.getLogger("lm")
     logger.setLevel(logging.INFO)
     formatter = logging.Formatter(
         '%(asctime)s - %(name)s - %(levelname)s - %(message)s')
-    if args.enable_ce:
-        fluid.default_startup_program().random_seed = SEED
     if args.log_path:
         file_handler = logging.FileHandler(args.log_path)
         file_handler.setLevel(logging.INFO)
@@ -94,67 +91,9 @@ def main():
         console_handler.setLevel(logging.INFO)
         console_handler.setFormatter(formatter)
         logger.addHandler(console_handler)
-
     logger.info('Running with args : {}'.format(args))
 
-    vocab_size = 10000
-    if model_type == "test":
-        num_layers = 1
-        batch_size = 2
-        hidden_size = 10
-        num_steps = 3
-        init_scale = 0.1
-        max_grad_norm = 5.0
-        epoch_start_decay = 1
-        max_epoch = 1
-        dropout = 0.0
-        lr_decay = 0.5
-        base_learning_rate = 1.0
-    elif model_type == "small":
-        num_layers = 2
-        batch_size = 20
-        hidden_size = 200
-        num_steps = 20
-        init_scale = 0.1
-        max_grad_norm = 5.0
-        epoch_start_decay = 4
-        max_epoch = 13
-        dropout = 0.0
-        lr_decay = 0.5
-        base_learning_rate = 1.0
-    elif model_type == "medium":
-        num_layers = 2
-        batch_size = 20
-        hidden_size = 650
-        num_steps = 35
-        init_scale = 0.05
-        max_grad_norm = 5.0
-        epoch_start_decay = 6
-        max_epoch = 39
-        dropout = 0.5
-        lr_decay = 0.8
-        base_learning_rate = 1.0
-    elif model_type == "large":
-        num_layers = 2
-        batch_size = 20
-        hidden_size = 1500
-        num_steps = 35
-        init_scale = 0.04
-        max_grad_norm = 10.0
-        epoch_start_decay = 14
-        max_epoch = 55
-        dropout = 0.65
-        lr_decay = 1.0 / 1.15
-        base_learning_rate = 1.0
-    else:
-        print("model type not support")
-        return
-
-    if args.batch_size > 0:
-        batch_size = args.batch_size
-
-    if args.max_epoch > 0:
-        max_epoch = args.max_epoch
+    config = RNNConfig(args)
 
     # define train program
     main_program = fluid.Program()
@@ -164,14 +103,14 @@ def main():
     with fluid.program_guard(main_program, startup_program):
         with fluid.unique_name.guard():
             res_vars = lm_model.lm_model(
-                hidden_size,
-                vocab_size,
-                batch_size,
-                num_layers=num_layers,
-                num_steps=num_steps,
-                init_scale=init_scale,
-                dropout=dropout,
-                rnn_model=rnn_model,
+                config.hidden_size,
+                config.vocab_size,
+                config.batch_size,
+                num_layers=config.num_layers,
+                num_steps=config.num_steps,
+                init_scale=config.init_scale,
+                dropout=config.dropout,
+                rnn_model=config.rnn_model,
                 use_py_reader=args.use_py_reader)
 
             if args.use_py_reader:
@@ -181,7 +120,7 @@ def main():
 
             fluid.clip.set_gradient_clip(
                 clip=fluid.clip.GradientClipByGlobalNorm(
-                    clip_norm=max_grad_norm))
+                    clip_norm=config.max_grad_norm))
 
             learning_rate = fluid.layers.create_global_var(
                 name="learning_rate",
@@ -199,14 +138,14 @@ def main():
     with fluid.program_guard(inference_program, inference_startup_program):
         with fluid.unique_name.guard():
             lm_model.lm_model(
-                hidden_size,
-                vocab_size,
-                batch_size,
-                num_layers=num_layers,
-                num_steps=num_steps,
-                init_scale=init_scale,
-                dropout=dropout,
-                rnn_model=rnn_model,
+                config.hidden_size,
+                config.vocab_size,
+                config.batch_size,
+                num_layers=config.num_layers,
+                num_steps=config.num_steps,
+                init_scale=config.init_scale,
+                dropout=config.dropout,
+                rnn_model=config.rnn_model,
                 use_py_reader=False)
 
     place = fluid.CUDAPlace(0) if args.use_gpu else fluid.CPUPlace()
@@ -243,6 +182,15 @@ def main():
     print("finished load data")
     train_data, valid_data, test_data, _ = raw_data
 
+    def generate_init_data():
+        init_hidden = np.zeros(
+            (config.num_layers, config.batch_size, config.hidden_size),
+            dtype='float32')
+        init_cell = np.zeros(
+            (config.num_layers, config.batch_size, config.hidden_size),
+            dtype='float32')
+        return init_hidden, init_cell
+
     def prepare_input(batch,
                       init_hidden=None,
                       init_cell=None,
@@ -250,11 +198,11 @@ def main():
                       with_lr=True,
                       device_count=1):
         x, y = batch
-        x = x.reshape((-1, num_steps, 1))
+        x = x.reshape((-1, config.num_steps, 1))
         y = y.reshape((-1, 1))
 
-        new_lr = base_learning_rate * (lr_decay**max(
-            epoch_id + 1 - epoch_start_decay, 0.0))
+        new_lr = config.base_learning_rate * (config.lr_decay**max(
+            epoch_id + 1 - config.epoch_start_decay, 0.0))
         if device_count > 1 and args.parallel:
             lr = np.ones((device_count), dtype='float32') * new_lr
         else:
@@ -274,13 +222,11 @@ def main():
 
     def eval(data):
         # when eval the batch_size set to 1
-        eval_data_iter = reader.get_data_iter(data, batch_size, num_steps)
+        eval_data_iter = reader.get_data_iter(data, config.batch_size,
+                                              config.num_steps)
         total_loss = 0.0
         iters = 0
-        init_hidden = np.zeros(
-            (num_layers, batch_size, hidden_size), dtype='float32')
-        init_cell = np.zeros(
-            (num_layers, batch_size, hidden_size), dtype='float32')
+        init_hidden, init_cell = generate_init_data()
         for batch_id, batch in enumerate(eval_data_iter):
             input_data_feed = prepare_input(
                 batch, init_hidden, init_cell, epoch_id=0, with_lr=False)
@@ -300,30 +246,23 @@ def main():
         ppl = np.exp(total_loss / iters)
         return ppl
 
-    def get_log_interval(data_len, batch_size):
-        num_batchs = data_len // batch_size
-        epoch_size = (num_batchs - 1) // num_steps
+    def get_log_interval(data_len):
+        num_batchs = data_len // config.batch_size
+        epoch_size = (num_batchs - 1) // config.num_steps
         log_interval = max(1, epoch_size // 10)
         return log_interval
 
-    def get_init_data():
-        init_hidden = np.zeros(
-            (num_layers, batch_size, hidden_size), dtype='float32')
-        init_cell = np.zeros(
-            (num_layers, batch_size, hidden_size), dtype='float32')
-        return init_hidden, init_cell
-
     def train_an_epoch(epoch_id, batch_times):
         # get train epoch size
-        log_interval = get_log_interval(len(train_data), batch_size)
-        train_data_iter = reader.get_data_iter(train_data, batch_size,
-                                               num_steps)
+        log_interval = get_log_interval(len(train_data))
+        train_data_iter = reader.get_data_iter(train_data, config.batch_size,
+                                               config.num_steps)
 
         total_loss = 0
         iters = 0
         for batch_id, batch in enumerate(train_data_iter):
             if batch_id == 0:
-                init_hidden, init_cell = get_init_data()
+                init_hidden, init_cell = generate_init_data()
             else:
                 init_hidden = None
                 init_cell = None
@@ -346,7 +285,7 @@ def main():
             lr = np.array(fetch_outs[1])
 
             total_loss += cost_train
-            iters += num_steps
+            iters += config.num_steps
             if batch_id > 0 and batch_id % log_interval == 0:
                 ppl = np.exp(total_loss / iters)
                 print(
@@ -358,9 +297,9 @@ def main():
 
     def train_an_epoch_py_reader(epoch_id, batch_times):
         # get train epoch size
-        log_interval = get_log_interval(len(train_data), batch_size)
+        log_interval = get_log_interval(len(train_data))
 
-        init_hidden, init_cell = get_init_data()
+        init_hidden, init_cell = generate_init_data()
         first_data_feeds = {}
         first_data_feeds["init_hidden"] = init_hidden
         first_data_feeds["init_cell"] = init_cell
@@ -391,7 +330,7 @@ def main():
                 lr = np.array(fetch_outs[1])
 
                 total_loss += cost_train
-                iters += num_steps
+                iters += config.num_steps
                 if batch_id > 0 and (log_interval == 0 or
                                      batch_id % log_interval == 0):
                     ppl = np.exp(total_loss / iters)
@@ -411,19 +350,19 @@ def main():
         if args.use_py_reader:
 
             def data_gen():
-                data_iter_size = batch_size // device_count
+                data_iter_size = config.batch_size // device_count
                 train_batches = reader.get_data_iter(train_data, data_iter_size,
-                                                     num_steps)
+                                                     config.num_steps)
                 for batch in train_batches:
                     x, y = batch
-                    x = x.reshape((-1, num_steps, 1))
+                    x = x.reshape((-1, config.num_steps, 1))
                     y = y.reshape((-1, 1))
                     yield x, y
 
             py_reader.decorate_tensor_provider(data_gen)
 
         total_time = 0.0
-        for epoch_id in range(max_epoch):
+        for epoch_id in range(config.max_epoch):
             batch_times = []
             epoch_start_time = time.time()
             if args.use_py_reader:
@@ -434,12 +373,12 @@ def main():
             total_time += epoch_time
             print(
                 "\nTrain epoch:[%d]; epoch Time: %.5f; ppl: %.5f; avg_time: %.5f steps/s \n"
-                % (epoch_id, epoch_time, train_ppl[0], len(batch_times) /
-                   sum(batch_times)))
+                % (epoch_id, epoch_time, train_ppl[0],
+                   len(batch_times) / sum(batch_times)))
 
             # FIXME(zjl): ppl[0] increases as batch_size increases. 
             # We should find a better way to calculate ppl by normalizing batch_size. 
-            if device_count == 1 and batch_size <= 20 and epoch_id == 0 and train_ppl[
+            if device_count == 1 and config.batch_size <= 20 and epoch_id == 0 and train_ppl[
                     0] > 1000:
                 # for bad init, after first epoch, the loss is over 1000
                 # no more need to continue
@@ -449,7 +388,7 @@ def main():
                 print("Abort this training process and please start again.")
                 return
 
-            if epoch_id == max_epoch - 1 and args.enable_ce:
+            if epoch_id == config.max_epoch - 1 and args.enable_ce:
                 # kpis
                 print("ptblm\tlstm_language_model_%s_duration_card%d\t%s" %
                       (args.rnn_model, device_count, total_time / max_epoch))
@@ -464,14 +403,16 @@ def main():
                 epoch_size = (batch_len - 1) // num_steps
                 return epoch_size >= 1
 
-            valid_data_valid = is_valid_data(valid_data, batch_size, num_steps)
+            valid_data_valid = is_valid_data(valid_data, config.batch_size,
+                                             config.num_steps)
             if valid_data_valid:
                 valid_ppl = eval(valid_data)
                 print("Valid ppl: %.5f" % valid_ppl[0])
             else:
                 print(
                     'WARNING: length of valid_data is {}, which is not enough for batch_size {} and num_steps {}'.
-                    format(len(valid_data), batch_size, num_steps))
+                    format(
+                        len(valid_data), config.batch_size, config.num_steps))
 
             save_model_dir = os.path.join("model_new/", str(epoch_id))
             fluid.io.save_persistables(

--- a/PaddleNLP/language_model/train.py
+++ b/PaddleNLP/language_model/train.py
@@ -419,7 +419,7 @@ def main():
                     format(
                         len(valid_data), config.batch_size, config.num_steps))
 
-            save_model_dir = os.path.join("model_new/", str(epoch_id))
+            save_model_dir = os.path.join(args.save_model_dir, str(epoch_id))
             fluid.io.save_persistables(
                 executor=exe, dirname=save_model_dir, main_program=main_program)
             print("Saved model to: %s.\n" % save_model_dir)

--- a/PaddleNLP/models/language_model/lm_model.py
+++ b/PaddleNLP/models/language_model/lm_model.py
@@ -295,9 +295,10 @@ def lm_model(hidden_size,
     init_cell.persistable = True
     init_hidden.persistable = True
 
-    init_hidden = layers.reshape(
+    init_hidden_reshape = layers.reshape(
         init_hidden, shape=[num_layers, -1, hidden_size])
-    init_cell = layers.reshape(init_cell, shape=[num_layers, -1, hidden_size])
+    init_cell_reshape = layers.reshape(
+        init_cell, shape=[num_layers, -1, hidden_size])
 
     x_emb = layers.embedding(
         input=x,
@@ -319,13 +320,19 @@ def lm_model(hidden_size,
 
     if rnn_model == "padding":
         rnn_out, last_hidden, last_cell = padding_rnn(
-            x_emb, len=num_steps, init_hidden=init_hidden, init_cell=init_cell)
+            x_emb,
+            len=num_steps,
+            init_hidden=init_hidden_reshape,
+            init_cell=init_cell_reshape)
     elif rnn_model == "static":
         rnn_out, last_hidden, last_cell = encoder_static(
-            x_emb, len=num_steps, init_hidden=init_hidden, init_cell=init_cell)
+            x_emb,
+            len=num_steps,
+            init_hidden=init_hidden_reshape,
+            init_cell=init_cell_reshape)
     elif rnn_model == "cudnn":
         x_emb = layers.transpose(x_emb, perm=[1, 0, 2])
-        rnn_out, last_hidden, last_cell = layers.lstm( x_emb, init_hidden, init_cell,  num_steps, hidden_size, num_layers, \
+        rnn_out, last_hidden, last_cell = layers.lstm(x_emb, init_hidden_reshape, init_cell_reshape,  num_steps, hidden_size, num_layers, \
                 is_bidirec=False, \
                 default_initializer=fluid.initializer.UniformInitializer(low=-init_scale, high=init_scale) )
         rnn_out = layers.transpose(rnn_out, perm=[1, 0, 2])

--- a/PaddleNLP/models/language_model/lm_model.py
+++ b/PaddleNLP/models/language_model/lm_model.py
@@ -28,8 +28,9 @@ def lm_model(hidden_size,
              num_layers=2,
              num_steps=20,
              init_scale=0.1,
-             dropout=None, 
-             rnn_model='static'):
+             dropout=None,
+             rnn_model='static',
+             use_py_reader=False):
     def padding_rnn(input_embedding, len=3, init_hidden=None, init_cell=None):
         weight_1_arr = []
         weight_2_arr = []
@@ -180,16 +181,20 @@ def lm_model(hidden_size,
                 init_hidden, axes=[0], starts=[i], ends=[i + 1])
             pre_cell = layers.slice(
                 init_cell, axes=[0], starts=[i], ends=[i + 1])
-            pre_hidden = layers.reshape(pre_hidden, shape=[-1, hidden_size])
-            pre_cell = layers.reshape(pre_cell, shape=[-1, hidden_size])
+            pre_hidden = layers.reshape(
+                pre_hidden, shape=[-1, hidden_size], inplace=True)
+            pre_cell = layers.reshape(
+                pre_cell, shape=[-1, hidden_size], inplace=True)
             hidden_array.append(pre_hidden)
             cell_array.append(pre_cell)
 
         res = []
+        sliced_inputs = layers.split(
+            input_embedding, num_or_sections=len, dim=1)
+
         for index in range(len):
-            input = layers.slice(
-                input_embedding, axes=[1], starts=[index], ends=[index + 1])
-            input = layers.reshape(input, shape=[-1, hidden_size])
+            input = sliced_inputs[index]
+            input = layers.reshape(input, shape=[-1, hidden_size], inplace=True)
             for k in range(num_layers):
                 pre_hidden = hidden_array[k]
                 pre_cell = cell_array[k]
@@ -202,9 +207,31 @@ def lm_model(hidden_size,
                 gate_input = layers.elementwise_add(gate_input, bias)
                 i, j, f, o = layers.split(gate_input, num_or_sections=4, dim=-1)
 
-                c = pre_cell * layers.sigmoid(f) + layers.sigmoid(
-                    i) * layers.tanh(j)
-                m = layers.tanh(c) * layers.sigmoid(o)
+                try:
+                    from paddle.fluid.contrib.layers import fused_elemwise_activation
+                    # layers.sigmoid(i) * layers.tanh(j)
+                    tmp0 = fused_elemwise_activation(
+                        x=layers.tanh(j),
+                        y=i,
+                        functor_list=['elementwise_mul', 'sigmoid'],
+                        save_intermediate_out=False)
+                    # pre_cell * layers.sigmoid(f)
+                    tmp1 = fused_elemwise_activation(
+                        x=pre_cell,
+                        y=f,
+                        functor_list=['elementwise_mul', 'sigmoid'],
+                        save_intermediate_out=False)
+                    c = tmp0 + tmp1
+                    # layers.tanh(c) * layers.sigmoid(o)
+                    m = fused_elemwise_activation(
+                        x=layers.tanh(c),
+                        y=o,
+                        functor_list=['elementwise_mul', 'sigmoid'],
+                        save_intermediate_out=False)
+                except ImportError:
+                    c = pre_cell * layers.sigmoid(f) + layers.sigmoid(
+                        i) * layers.tanh(j)
+                    m = layers.tanh(c) * layers.sigmoid(o)
 
                 hidden_array[k] = m
                 cell_array[k] = c
@@ -216,25 +243,57 @@ def lm_model(hidden_size,
                         dropout_prob=dropout,
                         dropout_implementation='upscale_in_train')
 
-            res.append(layers.reshape(input, shape=[1, -1, hidden_size]))
-        real_res = layers.concat(res, 0)
-        real_res = layers.transpose(x=real_res, perm=[1, 0, 2])
+            res.append(input)
+
         last_hidden = layers.concat(hidden_array, 1)
         last_hidden = layers.reshape(
-            last_hidden, shape=[-1, num_layers, hidden_size])
+            last_hidden, shape=[-1, num_layers, hidden_size], inplace=True)
         last_hidden = layers.transpose(x=last_hidden, perm=[1, 0, 2])
+
         last_cell = layers.concat(cell_array, 1)
         last_cell = layers.reshape(
             last_cell, shape=[-1, num_layers, hidden_size])
         last_cell = layers.transpose(x=last_cell, perm=[1, 0, 2])
 
+        real_res = layers.concat(res, 0)
+        real_res = layers.reshape(
+            real_res, shape=[len, -1, hidden_size], inplace=True)
+        real_res = layers.transpose(x=real_res, perm=[1, 0, 2])
+
         return real_res, last_hidden, last_cell
 
-    x = layers.data(name="x", shape=[-1, 1, 1], dtype='int64')
-    y = layers.data(name="y", shape=[-1, 1], dtype='float32')
+    batch_size_each = batch_size // fluid.core.get_cuda_device_count()
+    if use_py_reader:
+        feed_shapes = [[batch_size_each, num_steps, 1],
+                       [batch_size_each * num_steps, 1]]
+        py_reader = fluid.layers.py_reader(
+            capacity=16, shapes=feed_shapes, dtypes=['int64', 'int64'])
+        x, y = fluid.layers.read_file(py_reader)
+    else:
+        x = layers.data(
+            name="x",
+            shape=[batch_size_each, num_steps, 1],
+            dtype='int64',
+            append_batch_size=False)
+        y = layers.data(
+            name="y",
+            shape=[batch_size_each * num_steps, 1],
+            dtype='int64',
+            append_batch_size=False)
 
-    init_hidden = layers.data(name="init_hidden", shape=[1], dtype='float32')
-    init_cell = layers.data(name="init_cell", shape=[1], dtype='float32')
+    init_hidden = layers.data(
+        name="init_hidden",
+        shape=[num_layers, batch_size_each, hidden_size],
+        dtype='float32',
+        append_batch_size=False)
+    init_cell = layers.data(
+        name="init_cell",
+        shape=[num_layers, batch_size_each, hidden_size],
+        dtype='float32',
+        append_batch_size=False)
+
+    init_cell.persistable = True
+    init_hidden.persistable = True
 
     init_hidden = layers.reshape(
         init_hidden, shape=[num_layers, -1, hidden_size])
@@ -250,13 +309,14 @@ def lm_model(hidden_size,
             initializer=fluid.initializer.UniformInitializer(
                 low=-init_scale, high=init_scale)))
 
-    x_emb = layers.reshape(x_emb, shape=[-1, num_steps, hidden_size])
+    x_emb = layers.reshape(
+        x_emb, shape=[-1, num_steps, hidden_size], inplace=True)
     if dropout != None and dropout > 0.0:
         x_emb = layers.dropout(
             x_emb,
             dropout_prob=dropout,
             dropout_implementation='upscale_in_train')
-    
+
     if rnn_model == "padding":
         rnn_out, last_hidden, last_cell = padding_rnn(
             x_emb, len=num_steps, init_hidden=init_hidden, init_cell=init_cell)
@@ -264,16 +324,17 @@ def lm_model(hidden_size,
         rnn_out, last_hidden, last_cell = encoder_static(
             x_emb, len=num_steps, init_hidden=init_hidden, init_cell=init_cell)
     elif rnn_model == "cudnn":
-        x_emb = layers.transpose( x_emb, perm=[1, 0, 2])
+        x_emb = layers.transpose(x_emb, perm=[1, 0, 2])
         rnn_out, last_hidden, last_cell = layers.lstm( x_emb, init_hidden, init_cell,  num_steps, hidden_size, num_layers, \
                 is_bidirec=False, \
                 default_initializer=fluid.initializer.UniformInitializer(low=-init_scale, high=init_scale) )
-        rnn_out = layers.transpose( rnn_out, perm=[1, 0, 2])
+        rnn_out = layers.transpose(rnn_out, perm=[1, 0, 2])
     else:
-        print( "type not support")
+        print("type not support")
         return
-    rnn_out = layers.reshape(rnn_out, shape=[-1, num_steps, hidden_size])
 
+    rnn_out = layers.reshape(
+        rnn_out, shape=[-1, num_steps, hidden_size], inplace=True)
 
     softmax_weight = layers.create_parameter([hidden_size, vocab_size], dtype="float32", name="softmax_weight", \
             default_initializer=fluid.initializer.UniformInitializer(low=-init_scale, high=init_scale))
@@ -282,18 +343,25 @@ def lm_model(hidden_size,
 
     projection = layers.matmul(rnn_out, softmax_weight)
     projection = layers.elementwise_add(projection, softmax_bias)
-
-    projection = layers.reshape(projection, shape=[-1, vocab_size])
-    #y = layers.reshape( y, shape=[-1, vocab_size])
+    projection = layers.reshape(
+        projection, shape=[-1, vocab_size], inplace=True)
 
     loss = layers.softmax_with_cross_entropy(
         logits=projection, label=y, soft_label=False)
 
-    loss = layers.reshape(loss, shape=[-1, num_steps])
+    loss = layers.reshape(loss, shape=[-1, num_steps], inplace=True)
     loss = layers.reduce_mean(loss, dim=[0])
     loss = layers.reduce_sum(loss)
 
-    loss.permissions = True
+    loss.persistable = True
+    last_cell.persistable = True
+    last_hidden.persistable = True
+
+    layers.assign(input=last_cell, output=init_cell)
+    layers.assign(input=last_hidden, output=init_hidden)
 
     feeding_list = ['x', 'y', 'init_hidden', 'init_cell']
-    return loss, last_hidden, last_cell, feeding_list
+    if use_py_reader:
+        return loss, last_hidden, last_cell, feeding_list, py_reader
+    else:
+        return loss, last_hidden, last_cell, feeding_list


### PR DESCRIPTION
We changed a lot of the PaddingRNN codes, include both the model configuration and the training options. So we need to update those changes to here.

I test the develop branch use:
```
+ python train.py --data_path data/simple-examples/data/ --model_type small --rnn_model static --enable_ce --use_gpu True
2019-06-17 06:58:47,642 - lm - INFO - Running with args : Namespace(data_path='data/simple-examples/data/', enable_ce=True, log_path=None, model_type='small', para_init=False, rnn_model='static', use_gpu=True)
W0617 06:58:49.498152  4694 device_context.cc:259] Please NOTE: device: 0, CUDA Capability: 70, Driver API Version: 10.1, Runtime API Version: 9.0 
W0617 06:58:49.506192  4694 device_context.cc:267] device: 0, cuDNN Version: 7.5.
.
.
.
python train.py \
      --data_path data/simple-examples/data/ \
      --model_type ${model_type} \
      --rnn_model static \
      --enable_ce \
      --use_gpu True
```

- small model:
```
epoch id 12
ppl  232 44.82514 0.001953125
ppl  464 49.39149 0.001953125
ppl  696 47.661358 0.001953125
ppl  928 46.72023 0.001953125
ppl  1160 46.184597 0.001953125
ppl  1392 44.540607 0.001953125
ppl  1624 43.820793 0.001953125
ppl  1856 43.23518 0.001953125
ppl  2088 41.79701 0.001953125
ppl  2320 40.787346 0.001953125
train ppl 40.786976
ptblm lstm_language_model_static_duration_card1 70.1848174242
ptblm lstm_language_model_static_loss_card1 40.786976
valid ppl 119.65324
test ppl 114.91723
```

- large model:
```
+ python train.py --data_path data/simple-examples/data/ --model_type large --rnn_model static --enable_ce --use_gpu True
2019-06-17 07:16:50,873 - lm - INFO - Running with args : Namespace(data_path='data/simple-examples/data/', enable_ce=True, log_path=None, model_type='large', para_init=False, rnn_model='static', use_gpu=True)
W0617 07:16:53.597585  4710 device_context.cc:259] Please NOTE: device: 0, CUDA Capability: 70, Driver API Version: 10.1, Runtime API Version: 9.0
W0617 07:16:53.602998  4710 device_context.cc:267] device: 0, cuDNN Version: 7.5.
.
.
.
epoch id 54
ppl  132 37.065334 0.0032462992
ppl  264 40.845306 0.0032462992
ppl  396 39.749107 0.0032462992
ppl  528 39.512344 0.0032462992
ppl  660 39.659756 0.0032462992
ppl  792 38.83683 0.0032462992
ppl  924 38.86937 0.0032462992
ppl  1056 39.0496 0.0032462992
ppl  1188 38.37251 0.0032462992
ppl  1320 38.06603 0.0032462992
train ppl 38.081997
ptblm lstm_language_model_static_duration_card1 125.04247805
ptblm lstm_language_model_static_loss_card1 38.081997
valid ppl 82.77821
test ppl 78.73715  
```

Then I test this PR use:
```
python train.py \
      --data_path data/simple-examples/data/ \
      --model_type ${model_type} \
      --rnn_model static \
      --use_py_reader True \
      --enable_ce \
      --use_gpu True
```

- small model
```
+ python train.py --data_path data/simple-examples/data/ --model_type small --rnn_model static --use_py_reader True --enable_ce --use_gpu True
2019-06-18 03:25:14,878 - lm - INFO - Running with args : Namespace(batch_size=0, data_path='data/simple-examples/data/', enable_ce=True, log_path=None, max_epoch=0, model_type='small', para_init=False, parallel=True, rnn_model='static', save_model_dir='models', use_gpu=True, use_py_reader=True)
W0618 03:25:16.665827  5481 device_context.cc:259] Please NOTE: device: 0, CUDA Capability: 70, Driver API Version: 10.1, Runtime API Version: 9.0 
W0618 03:25:16.671789  5481 device_context.cc:267] device: 0, cuDNN Version: 7.5.
.
.
.
-- Epoch:[12]; Batch:[232]; Time: 0.02059 s; ppl: 45.17641, lr: 0.00195
-- Epoch:[12]; Batch:[464]; Time: 0.02319 s; ppl: 49.69373, lr: 0.00195
-- Epoch:[12]; Batch:[696]; Time: 0.02119 s; ppl: 47.89302, lr: 0.00195
-- Epoch:[12]; Batch:[928]; Time: 0.02276 s; ppl: 46.88626, lr: 0.00195
-- Epoch:[12]; Batch:[1160]; Time: 0.02284 s; ppl: 46.28157, lr: 0.00195
-- Epoch:[12]; Batch:[1392]; Time: 0.02228 s; ppl: 44.61953, lr: 0.00195
-- Epoch:[12]; Batch:[1624]; Time: 0.02480 s; ppl: 43.86269, lr: 0.00195
-- Epoch:[12]; Batch:[1856]; Time: 0.02261 s; ppl: 43.27738, lr: 0.00195
-- Epoch:[12]; Batch:[2088]; Time: 0.02492 s; ppl: 41.82330, lr: 0.00195
-- Epoch:[12]; Batch:[2320]; Time: 0.02289 s; ppl: 40.82926, lr: 0.00195

Train epoch:[12]; epoch Time: 53.97107; ppl: 40.82766; avg_time: 43.06617 steps/s 

ptblm lstm_language_model_static_duration_card1 49.5954330701
ptblm lstm_language_model_static_loss_card1 40.827663
Valid ppl: 119.90054
Saved model to: models/12.

Test ppl: 115.99717       
```

- large model
```
+ python train.py --data_path data/simple-examples/data/ --model_type large --rnn_model static --use_py_reader True --enable_ce --use_gpu True
2019-06-18 08:22:52,034 - lm - INFO - Running with args : Namespace(batch_size=0, data_path='data/simple-examples/data/', enable_ce=True, log_path=None, max_epoch=0, model_type='large', para_init=False, parallel=True, rnn_model='static', save_model_dir='models', use_gpu=True, use_py_reader=True)
W0618 08:22:54.477843  5797 device_context.cc:259] Please NOTE: device: 0, CUDA Capability: 70, Driver API Version: 10.1, Runtime API Version: 9.0 
W0618 08:22:54.483436  5797 device_context.cc:267] device: 0, cuDNN Version: 7.5.
.
.
.
-- Epoch:[54]; Batch:[132]; Time: 0.05313 s; ppl: 36.70142, lr: 0.00325
-- Epoch:[54]; Batch:[264]; Time: 0.05284 s; ppl: 40.47433, lr: 0.00325
-- Epoch:[54]; Batch:[396]; Time: 0.05262 s; ppl: 39.36209, lr: 0.00325
-- Epoch:[54]; Batch:[528]; Time: 0.05793 s; ppl: 39.15080, lr: 0.00325
-- Epoch:[54]; Batch:[660]; Time: 0.05314 s; ppl: 39.24402, lr: 0.00325
-- Epoch:[54]; Batch:[792]; Time: 0.05264 s; ppl: 38.42751, lr: 0.00325
-- Epoch:[54]; Batch:[924]; Time: 0.05725 s; ppl: 38.41288, lr: 0.00325
-- Epoch:[54]; Batch:[1056]; Time: 0.05902 s; ppl: 38.57289, lr: 0.00325
-- Epoch:[54]; Batch:[1188]; Time: 0.05940 s; ppl: 37.86667, lr: 0.00325
-- Epoch:[54]; Batch:[1320]; Time: 0.05668 s; ppl: 37.54736, lr: 0.00325

Train epoch:[54]; epoch Time: 75.54808; ppl: 37.56197; avg_time: 17.59101 steps/s

ptblm lstm_language_model_static_duration_card1 74.7825333422
ptblm lstm_language_model_static_loss_card1 37.56197
Valid ppl: 82.56120
Saved model to: models/54.

Test ppl: 78.93229 
```