### PR TITLE
fix bug in mask rcnn architecture

### DIFF
--- a/PaddleCV/object_detection/configs/mask_rcnn_se154_vd_fpn_s1x.yml
+++ b/PaddleCV/object_detection/configs/mask_rcnn_se154_vd_fpn_s1x.yml
@@ -8,7 +8,7 @@ use_gpu: True
 log_smooth_window: 20
 save_dir: output
 pretrain_weights: https://paddle-imagenet-models-name.bj.bcebos.com/SE154_vd_pretrained.tar
-weights: output/mask_rcnn_se154_fpn_s1x/model_final/ 
+weights: output/mask_rcnn_se154_vd_fpn_s1x/model_final/ 
 metric: COCO
 
 MaskRCNN:
@@ -51,13 +51,13 @@ FPNRPNHead:
   train_proposal:
     min_size: 0.0
     nms_thresh: 0.7
-    post_nms_top_n: 2000
     pre_nms_top_n: 2000
+    post_nms_top_n: 2000
   test_proposal:
     min_size: 0.0
     nms_thresh: 0.7
-    post_nms_top_n: 1000
     pre_nms_top_n: 1000
+    post_nms_top_n: 1000
 
 FPNRoIAlign:
   canconical_level: 4

--- a/PaddleCV/object_detection/ppdet/modeling/architectures/mask_rcnn.py
+++ b/PaddleCV/object_detection/ppdet/modeling/architectures/mask_rcnn.py
@@ -67,8 +67,9 @@ class MaskRCNN(object):
         assert mode in ['train', 'test'], \
             "only 'train' and 'test' mode is supported"
         if mode == 'train':
-            required_fields = ['gt_label', 'gt_box', 'gt_mask',
-                               'is_crowd', 'im_info']
+            required_fields = [
+                'gt_label', 'gt_box', 'gt_mask', 'is_crowd', 'im_info'
+            ]
         else:
             required_fields = ['im_shape', 'im_info']
         for var in required_fields:
@@ -85,12 +86,6 @@ class MaskRCNN(object):
         # RPN proposals
         rois = self.rpn_head.get_proposals(body_feats, im_info, mode=mode)
 
-        if self.fpn is None:
-            last_feat = body_feats[list(body_feats.keys())[-1]]
-            roi_feat = self.roi_extractor(last_feat, rois)
-        else:
-            roi_feat = self.roi_extractor(body_feats, rois, spatial_scale)
-
         if mode == 'train':
             rpn_loss = self.rpn_head.get_loss(im_info, feed_vars['gt_box'],
                                               feed_vars['is_crowd'])
@@ -103,6 +98,12 @@ class MaskRCNN(object):
                 im_info=feed_vars['im_info'])
             rois = outs[0]
             labels_int32 = outs[1]
+
+            if self.fpn is None:
+                last_feat = body_feats[list(body_feats.keys())[-1]]
+                roi_feat = self.roi_extractor(last_feat, rois)
+            else:
+                roi_feat = self.roi_extractor(body_feats, rois, spatial_scale)
 
             loss = self.bbox_head.get_loss(roi_feat, labels_int32, *outs[2:])
             loss.update(rpn_loss)
@@ -118,8 +119,8 @@ class MaskRCNN(object):
                 bbox_head_feat = self.bbox_head.get_head_feat()
                 feat = fluid.layers.gather(bbox_head_feat, roi_has_mask_int32)
             else:
-                feat = self.roi_extractor(body_feats, mask_rois, spatial_scale,
-                                          is_mask=True)
+                feat = self.roi_extractor(
+                    body_feats, mask_rois, spatial_scale, is_mask=True)
 
             mask_loss = self.mask_head.get_loss(feat, mask_int32)
             loss.update(mask_loss)
@@ -129,6 +130,13 @@ class MaskRCNN(object):
             return loss
 
         else:
+
+            if self.fpn is None:
+                last_feat = body_feats[list(body_feats.keys())[-1]]
+                roi_feat = self.roi_extractor(last_feat, rois)
+            else:
+                roi_feat = self.roi_extractor(body_feats, rois, spatial_scale)
+
             bbox_pred = self.bbox_head.get_prediction(roi_feat, rois, im_info,
                                                       feed_vars['im_shape'])
             bbox_pred = bbox_pred['bbox']
@@ -147,8 +155,8 @@ class MaskRCNN(object):
                 with switch.case(cond):
                     fluid.layers.assign(input=bbox_pred, output=mask_pred)
                 with switch.default():
-                    bbox = fluid.layers.slice(bbox_pred, [1],
-                                              starts=[2], ends=[6])
+                    bbox = fluid.layers.slice(
+                        bbox_pred, [1], starts=[2], ends=[6])
 
                     im_scale = fluid.layers.slice(
                         im_info, [1], starts=[2], ends=[3])


### PR DESCRIPTION
In train phase, rois in roi_extractor should be the output of bbox_assigner rather than rpn_head.get_proposals.