### PR TITLE
fix x0,y0 out of bound

### DIFF
--- a/PaddleCV/object_detection/ppdet/utils/coco_eval.py
+++ b/PaddleCV/object_detection/ppdet/utils/coco_eval.py
@@ -185,9 +185,9 @@ def mask2out(results, clsid2catid, resolution, thresh_binarize=0.5):
                 im_mask = np.zeros((im_h, im_w), dtype=np.uint8)
 
                 x0 = min(max(xmin, 0), im_w)
-                x1 = min(xmax + 1, im_w)
+                x1 = min(max(xmax + 1, 0), im_w)
                 y0 = min(max(ymin, 0), im_h)
-                y1 = min(ymax + 1, im_h)
+                y1 = min(max(ymax + 1, 0), im_h)
 
                 im_mask[y0:y1, x0:x1] = resized_mask[(y0 - ymin):(y1 - ymin), (
                     x0 - xmin):(x1 - xmin)]

--- a/PaddleCV/object_detection/ppdet/utils/coco_eval.py
+++ b/PaddleCV/object_detection/ppdet/utils/coco_eval.py
@@ -184,9 +184,9 @@ def mask2out(results, clsid2catid, resolution, thresh_binarize=0.5):
                     resized_mask > thresh_binarize, dtype=np.uint8)
                 im_mask = np.zeros((im_h, im_w), dtype=np.uint8)
 
-                x0 = max(xmin, 0)
+                x0 = min(max(xmin, 0), im_w)
                 x1 = min(xmax + 1, im_w)
-                y0 = max(ymin, 0)
+                y0 = min(max(ymin, 0), im_h)
                 y1 = min(ymax + 1, im_h)
 
                 im_mask[y0:y1, x0:x1] = resized_mask[(y0 - ymin):(y1 - ymin), (


### PR DESCRIPTION
**fix mask x0/y0 may out of width/height bound**
```python
print(im_id, [x0, x1, y0, y1], xmin, ymin, im_mask.shape, resized_mask.shape)
# 1 [208, 320, 345, 240] 208 345 (240, 320) (140, 219)
im_mask[y0:y1, x0:x1] = resized_mask[(y0 - ymin):(y1 - ymin), (x0 - xmin):(x1 - xmin)]
# im_mask[345:240, 208:320] = resize_mask[0:-95, 0: 112]
# ValueError: could not broadcast input array from shape (35,112) into shape (0,112)
```

