### PR TITLE
Fix Python syntax error in PaddleCV/metric_learning/_ce.py

### DIFF
--- a/PaddleCV/metric_learning/_ce.py
+++ b/PaddleCV/metric_learning/_ce.py
@@ -7,7 +7,7 @@ from kpi import CostKpi, DurationKpi, AccKpi
 
 # NOTE kpi.py should shared in models in some way!!!!
 
-train_cost_kpi = CostKpi('train_cost', 0.02 0, actived=True)
+train_cost_kpi = CostKpi('train_cost', 0.02, 0, actived=True)
 test_recall_kpi = AccKpi('test_recall', 0.02, 0, actived=True)
 
 tracking_kpis = [


### PR DESCRIPTION
The missing comma (,) is a syntax error in Python.  Discovered via #2449