### PR TITLE
add cuda check to show errors when run on paddle compiled with cpu only

### DIFF
--- a/PaddleCV/PaddleVideo/infer.py
+++ b/PaddleCV/PaddleVideo/infer.py
@@ -17,6 +17,7 @@ import sys
 import time
 import logging
 import argparse
+import ast
 import numpy as np
 try:
     import cPickle as pickle
@@ -27,6 +28,7 @@ import paddle.fluid as fluid
 from config import *
 import models
 from datareader import get_reader
+from utils import check_cuda
 
 logging.root.handlers = []
 FORMAT = '[%(levelname)s: %(filename)s: %(lineno)4d]: %(message)s'
@@ -47,7 +49,10 @@ def parse_args():
         default='configs/attention_cluster.txt',
         help='path to config file of model')
     parser.add_argument(
-        '--use_gpu', type=bool, default=True, help='default use gpu.')
+        '--use_gpu',
+        type=ast.literal_eval,
+        default=True,
+        help='default use gpu.')
     parser.add_argument(
         '--weights',
         type=str,
@@ -155,6 +160,8 @@ def infer(args):
 
 if __name__ == "__main__":
     args = parse_args()
+    # check whether the installed paddle is compiled with GPU
+    check_cuda(args.use_gpu)
     logger.info(args)
 
     infer(args)

--- a/PaddleCV/PaddleVideo/test.py
+++ b/PaddleCV/PaddleVideo/test.py
@@ -17,6 +17,7 @@ import sys
 import time
 import logging
 import argparse
+import ast
 import numpy as np
 import paddle.fluid as fluid
 
@@ -24,6 +25,7 @@ from config import *
 import models
 from datareader import get_reader
 from metrics import get_metrics
+from utils import check_cuda
 
 logging.root.handlers = []
 FORMAT = '[%(levelname)s: %(filename)s: %(lineno)4d]: %(message)s'
@@ -49,7 +51,10 @@ def parse_args():
         default=None,
         help='test batch size. None to use config file setting.')
     parser.add_argument(
-        '--use_gpu', type=bool, default=True, help='default use gpu.')
+        '--use_gpu',
+        type=ast.literal_eval,
+        default=True,
+        help='default use gpu.')
     parser.add_argument(
         '--weights',
         type=str,
@@ -141,6 +146,8 @@ def test(args):
 
 if __name__ == "__main__":
     args = parse_args()
+    # check whether the installed paddle is compiled with GPU
+    check_cuda(args.use_gpu)
     logger.info(args)
 
     test(args)

--- a/PaddleCV/PaddleVideo/train.py
+++ b/PaddleCV/PaddleVideo/train.py
@@ -16,6 +16,7 @@ import os
 import sys
 import time
 import argparse
+import ast
 import logging
 import numpy as np
 import paddle.fluid as fluid
@@ -25,6 +26,7 @@ import models
 from config import *
 from datareader import get_reader
 from metrics import get_metrics
+from utils import check_cuda
 
 logging.root.handlers = []
 FORMAT = '[%(levelname)s: %(filename)s: %(lineno)4d]: %(message)s'
@@ -67,7 +69,10 @@ def parse_args():
         help='path to resume training based on previous checkpoints. '
         'None for not resuming any checkpoints.')
     parser.add_argument(
-        '--use_gpu', type=bool, default=True, help='default use gpu.')
+        '--use_gpu',
+        type=ast.literal_eval,
+        default=True,
+        help='default use gpu.')
     parser.add_argument(
         '--no_use_pyreader',
         action='store_true',
@@ -100,7 +105,7 @@ def parse_args():
         help='mini-batch interval to log.')
     parser.add_argument(
         '--enable_ce',
-        type=bool,
+        type=ast.literal_eval,
         default=False,
         help='If set True, enable continuous evaluation job.')
     args = parser.parse_args()
@@ -277,6 +282,8 @@ def train(args):
 
 if __name__ == "__main__":
     args = parse_args()
+    # check whether the installed paddle is compiled with GPU
+    check_cuda(args.use_gpu)
     logger.info(args)
 
     if not os.path.exists(args.save_dir):

--- a/PaddleCV/PaddleVideo/utils.py
+++ b/PaddleCV/PaddleVideo/utils.py
@@ -40,8 +40,8 @@ class AttrDict(dict):
             self[key] = value
 
 def check_cuda(use_cuda, err = \
-    "\nYou can not set use_cuda = True in the model because you are using paddlepaddle-cpu.\n \
-    Please: 1. Install paddlepaddle-gpu to run your models on GPU or 2. Set use_cuda = False to run models on CPU.\n"
+    "\nYou can not set use_gpu = True in the model because you are using paddlepaddle-cpu.\n \
+    Please: 1. Install paddlepaddle-gpu to run your models on GPU or 2. Set use_gpu = False to run models on CPU.\n"
                                                                                                                      ):
     try:
         if use_cuda == True and fluid.is_compiled_with_cuda() == False:

--- a/PaddleCV/PaddleVideo/utils.py
+++ b/PaddleCV/PaddleVideo/utils.py
@@ -14,6 +14,8 @@
 
 import os
 import signal
+import paddle
+import paddle.fluid as fluid
 
 __all__ = ['AttrDict']
 
@@ -36,3 +38,14 @@ class AttrDict(dict):
             self.__dict__[key] = value
         else:
             self[key] = value
+
+def check_cuda(use_cuda, err = \
+    "\nYou can not set use_cuda = True in the model because you are using paddlepaddle-cpu.\n \
+    Please: 1. Install paddlepaddle-gpu to run your models on GPU or 2. Set use_cuda = False to run models on CPU.\n"
+                                                                                                                     ):
+    try:
+        if use_cuda == True and fluid.is_compiled_with_cuda() == False:
+            print(err)
+            sys.exit(1)
+    except Exception as e:
+        pass


### PR DESCRIPTION
Sometimes user would install cpu only paddle. So when use_gpu=True, the program should check whether paddle was compiled with gpu or cpu only. For the latter case, program will exit will error information to show that.