### PR TITLE
Prevent module instance from modifying global config

### DIFF
--- a/PaddleCV/PaddleDetection/ppdet/core/workspace.py
+++ b/PaddleCV/PaddleDetection/ppdet/core/workspace.py
@@ -21,6 +21,7 @@ import os
 import sys
 
 import yaml
+import copy
 
 from .config.schema import SchemaDict, extract_schema
 from .config.yaml_helpers import serializable
@@ -163,4 +164,7 @@ def create(cls_or_name, **kwargs):
                     kwargs[k] = target
             else:
                 raise ValueError("Unsupported injection type:", target_key)
+    # prevent modification of global config values of reference types
+    # (e.g., list, dict) from within the created module instances
+    kwargs = copy.deepcopy(kwargs)
     return cls(**kwargs)


### PR DESCRIPTION
some of the global config values are reference type, e.g., objects, lists or
dicts, if the created module instances modify those values (see FPN and
spatial_scale), global config will reflect these changes, and instances of the
same class created later will inherit the changed values