### PR TITLE
fix gt_id overflow and add README for windows

### DIFF
--- a/PaddleCV/yolov3/README.md
+++ b/PaddleCV/yolov3/README.md
@@ -94,6 +94,7 @@ dataset/coco/
        --class_num=${category_num}
 
 - 通过设置`export CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7`指定8卡GPU训练。
+- 若在Windows环境下训练模型，建议设置`--use_multiprocess=False`。
 - 可选参数见：
 
     python train.py --help

--- a/PaddleCV/yolov3/README_en.md
+++ b/PaddleCV/yolov3/README_en.md
@@ -95,6 +95,7 @@ Please make sure that pre-trained model is downloaded and loaded correctly, othe
        --class_num=${category_num}
 
 - Set `export CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7` to specifiy 8 GPUs to train. 
+- It is recommended to set `--use_multiprocess=False` when training on Windows.
 - For more help on arguments:
 
     python train.py --help

--- a/PaddleCV/yolov3/reader.py
+++ b/PaddleCV/yolov3/reader.py
@@ -104,7 +104,6 @@ class DataSetReader(object):
             if box[2] <= 0 and box[3] <= 0:
                 continue
 
-            img['gt_id'][gt_index] = np.int32(target['id'])
             img['gt_boxes'][gt_index] = box
             img['gt_labels'][gt_index] = \
                 self.category_to_id_map[target['category_id']]
@@ -121,7 +120,6 @@ class DataSetReader(object):
             assert os.path.exists(img['image']), \
                     "image {} not found.".format(img['image'])
             box_num = cfg.max_box_num
-            img['gt_id'] = np.zeros((cfg.max_box_num), dtype=np.int32)
             img['gt_boxes'] = np.zeros((cfg.max_box_num, 4), dtype=np.float32)
             img['gt_labels'] = np.zeros((cfg.max_box_num), dtype=np.int32)
             for k in ['date_captured', 'url', 'license', 'file_name']:


### PR DESCRIPTION
1.  remove unused gt_id, which may overflow in int32
2. add README for setting --use_multiprocess=False on Windows