### PR TITLE
update docs with cpu training

### DIFF
--- a/PaddleCV/PaddleDetection/docs/GETTING_STARTED.md
+++ b/PaddleCV/PaddleDetection/docs/GETTING_STARTED.md
@@ -20,6 +20,8 @@ python tools/train.py -c configs/faster_rcnn_r50_1x.yml
 
 ```bash
 export CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7
+# or run on CPU with:
+# export CPU_NUM=8
 python tools/train.py -c configs/faster_rcnn_r50_1x.yml
 ```
 
@@ -28,6 +30,7 @@ python tools/train.py -c configs/faster_rcnn_r50_1x.yml
 - Pretrained model is downloaded automatically and cached in `~/.cache/paddle/weights`.
 - Model checkpoints is saved in `output` by default (configurable).
 - To check out hyper parameters used, please refer to the config file.
+- RCNN models training on CPU is not supported on PaddlePaddle<=1.5.1 and will be fixed on later version.
 
 Alternating between training epoch and evaluation run is possible, simply pass
 in `--eval` to do so (tested with `SSD` detector on Pascal-VOC, not

--- a/PaddleCV/PaddleDetection/docs/GETTING_STARTED_cn.md
+++ b/PaddleCV/PaddleDetection/docs/GETTING_STARTED_cn.md
@@ -19,6 +19,8 @@ python tools/train.py -c configs/faster_rcnn_r50_1x.yml
 
 ```bash
 export CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7
+# 若使用CPU，则执行
+# export CPU_NUM=8
 python tools/train.py -c configs/faster_rcnn_r50_1x.yml
 ```
 
@@ -27,7 +29,7 @@ python tools/train.py -c configs/faster_rcnn_r50_1x.yml
 - 预训练模型自动下载并保存在`〜/.cache/paddle/weights`中。
 - 模型checkpoints默认保存在`output`中（可配置）。
 - 更多参数配置，请参考配置文件。
-
+- RCNN系列模型CPU训练在PaddlePaddle 1.5.1及以下版本暂不支持，将在下个版本修复。
 
 可通过设置`--eval`在训练epoch中交替执行评估（已在在Pascal-VOC数据集上
 用`SSD`检测器验证，不推荐在COCO数据集上的两阶段模型上执行交替评估）


### PR DESCRIPTION
Update docs to inform users that cpu training is only supported on PaddlePaddle>=1.5.2