### PR TITLE
Fix a bug in command line option parsing

### DIFF
--- a/PaddleCV/PaddleDetection/ppdet/utils/cli.py
+++ b/PaddleCV/PaddleDetection/ppdet/utils/cli.py
@@ -68,7 +68,8 @@ class ArgsParser(ArgumentParser):
                 config[k] = yaml.load(v, Loader=yaml.Loader)
             else:
                 keys = k.split('.')
-                config[keys[0]] = {}
+                if keys[0] not in config:
+                    config[keys[0]] = {}
                 cur = config[keys[0]]
                 for idx, key in enumerate(keys[1:]):
                     if idx == len(keys) - 2:


### PR DESCRIPTION
option should not be overridden by subsequent options of the same module