### PR TITLE
Fix `maxsplit` error in py2

### DIFF
--- a/PaddleCV/PaddleDetection/ppdet/utils/cli.py
+++ b/PaddleCV/PaddleDetection/ppdet/utils/cli.py
@@ -63,7 +63,7 @@ class ArgsParser(ArgumentParser):
             return config
         for s in opts:
             s = s.strip()
-            k, v = s.split('=', maxsplit=1)
+            k, v = s.split('=', 1)
             if '.' not in k:
                 config[k] = yaml.load(v, Loader=yaml.Loader)
             else:


### PR DESCRIPTION
python 2 `split` only accept positional args