### PR TITLE
Fix BERT error temporarily when gc is enabled

### DIFF
--- a/PaddleNLP/dialogue_model_toolkit/dialogue_general_understanding/.run_ce.sh
+++ b/PaddleNLP/dialogue_model_toolkit/dialogue_general_understanding/.run_ce.sh
@@ -50,6 +50,11 @@ train_mrda(){
   --enable_ce
 }
 
+# FIXME(zjl): this model would fail when GC is enabled,
+# but it seems that this error is from the model itself.
+# See issue here: https://github.com/PaddlePaddle/Paddle/issues/18994#event-2532039900       
+# To fix ce, disable gc in this model temporarily.  
+export FLAGS_eager_delete_tensor_gb=-1
 
 cudaid=${multi:=0,1,2,3}
 export CUDA_VISIBLE_DEVICES=$cudaid


### PR DESCRIPTION
BERT fails when gc is enabled. See [Paddle#18994](https://github.com/PaddlePaddle/Paddle/issues/18994#event-2532039900). But it seems that the model itself is wrong. Fix CE temporarily by disabling gc in BERT.