### PR TITLE
[cherry-pick] fix mobilenet backbone conv learning_rate

### DIFF
--- a/PaddleCV/PaddleDetection/configs/ssd_mobilenet_v1_voc.yml
+++ b/PaddleCV/PaddleDetection/configs/ssd_mobilenet_v1_voc.yml
@@ -30,6 +30,7 @@ SSD:
 MobileNet:
   norm_decay: 0.
   conv_group_scale: 1
+  conv_learning_rate: 0.1
   extra_block_filters: [[256, 512], [128, 256], [128, 256], [64, 128]]
   with_extra_blocks: true
 

--- a/PaddleCV/PaddleDetection/ppdet/modeling/backbones/mobilenet.py
+++ b/PaddleCV/PaddleDetection/ppdet/modeling/backbones/mobilenet.py
@@ -34,6 +34,7 @@ class MobileNet(object):
         norm_type (str): normalization type, 'bn' and 'sync_bn' are supported
         norm_decay (float): weight decay for normalization layer weights
         conv_group_scale (int): scaling factor for convolution groups
+        conv_learning_rate(float): learning rate scale factor of conv
         with_extra_blocks (bool): if extra blocks should be added
         extra_block_filters (list): number of filter for each extra block
     """
@@ -42,12 +43,14 @@ class MobileNet(object):
                  norm_type='bn',
                  norm_decay=0.,
                  conv_group_scale=1,
+                 conv_learning_rate=1.0,
                  with_extra_blocks=False,
                  extra_block_filters=[[256, 512], [128, 256], [128, 256],
                                       [64, 128]]):
         self.norm_type = norm_type
         self.norm_decay = norm_decay
         self.conv_group_scale = conv_group_scale
+        self.conv_learning_rate = conv_learning_rate
         self.with_extra_blocks = with_extra_blocks
         self.extra_block_filters = extra_block_filters
 
@@ -62,7 +65,7 @@ class MobileNet(object):
                    use_cudnn=True,
                    name=None):
         parameter_attr = ParamAttr(
-            learning_rate=0.1,
+            learning_rate=self.conv_learning_rate,
             initializer=fluid.initializer.MSRA(),
             name=name + "_weights")
         conv = fluid.layers.conv2d(


### PR DESCRIPTION
**cherry pick parts of https://github.com/PaddlePaddle/models/pull/2801 to release/1.5**
1. mobilenet conv learning rate factor as 0.1 is a special config for ssd
2. yolov3_mobilnet use conv learning rate factor as 1.0