### PR TITLE
ctr model: add sequence pool after emb layer

### DIFF
--- a/PaddleRec/ctr/network_conf.py
+++ b/PaddleRec/ctr/network_conf.py
@@ -107,7 +107,8 @@ def ctr_deepfm_model(factor_size, sparse_feature_dim, dense_feature_dim, sparse_
 def ctr_dnn_model(embedding_size, sparse_feature_dim, use_py_reader=True):
 
     def embedding_layer(input):
-        return fluid.layers.embedding(
+        """embedding_layer"""
+        emb = fluid.layers.embedding(
             input=input,
             is_sparse=True,
             # you need to patch https://github.com/PaddlePaddle/Paddle/pull/14190
@@ -116,6 +117,7 @@ def ctr_dnn_model(embedding_size, sparse_feature_dim, use_py_reader=True):
             size=[sparse_feature_dim, embedding_size],
             param_attr=fluid.ParamAttr(name="SparseFeatFactors",
                                        initializer=fluid.initializer.Uniform()))
+        return fluid.layers.sequence_pool(input=emb, pool_type='average')
 
     dense_input = fluid.layers.data(
         name="dense_input", shape=[dense_feature_dim], dtype='float32')


### PR DESCRIPTION
this sequence pool can filter the lod info of the embedding layer in ctr_dnn_model

this commit does not change any behavior when training.

but in the following process, lod info might cause some trouble.

Plus, in network_conf.py, ctr_deepfm_model has added this sequence_pool layer.

So this commit will make two model similar network structure.