### PR TITLE
Remove deprecated fluid.memory_optimize

### DIFF
--- a/AutoDL/LRC/train_mixup.py
+++ b/AutoDL/LRC/train_mixup.py
@@ -176,7 +176,6 @@ def train(model, args, im_shape, steps_one_epoch):
     test_py_reader.decorate_paddle_reader(test_reader)
 
     fluid.clip.set_gradient_clip(fluid.clip.GradientClipByNorm(args.grad_clip))
-    fluid.memory_optimize(fluid.default_main_program())
 
     def save_model(postfix, main_prog):
         model_path = os.path.join(args.model_path, postfix)

--- a/PaddleCV/deeplabv3+/eval.py
+++ b/PaddleCV/deeplabv3+/eval.py
@@ -102,11 +102,6 @@ with fluid.program_guard(tp, sp):
     miou, out_wrong, out_correct = mean_iou(pred, label)
 
 tp = tp.clone(True)
-fluid.memory_optimize(
-    tp,
-    print_log=False,
-    skip_opt_set=set([pred.name, miou, out_wrong, out_correct]),
-    level=1)
 
 place = fluid.CPUPlace()
 if args.use_gpu:

--- a/PaddleCV/face_detection/profile.py
+++ b/PaddleCV/face_detection/profile.py
@@ -108,8 +108,6 @@ def train(args, config, train_file_list, optimizer_method):
                     regularization=fluid.regularizer.L2Decay(0.0005),
                 )
             optimizer.minimize(loss)
-    fluid.memory_optimize(train_prog)
-
 
     place = fluid.CUDAPlace(0) if use_gpu else fluid.CPUPlace()
     exe = fluid.Executor(place)

--- a/PaddleCV/face_detection/train.py
+++ b/PaddleCV/face_detection/train.py
@@ -56,7 +56,6 @@ add_arg('model_save_dir',   str,   'output',        "The path to save model.")
 add_arg('resize_h',         int,   640,             "The resized image height.")
 add_arg('resize_w',         int,   640,             "The resized image width.")
 add_arg('mean_BGR',         str,   '104., 117., 123.', "Mean value for B,G,R channel which will be subtracted.")
-add_arg('with_mem_opt',     bool,  True,            "Whether to use memory optimization or not.")
 add_arg('pretrained_model', str,   './vgg_ilsvrc_16_fc_reduced/', "The init model path.")
 add_arg('data_dir',         str,   'data',          "The base dir of dataset")
 add_arg('use_multiprocess', bool,  True,            "Whether use multi-process for data preprocessing.")
@@ -138,7 +137,6 @@ def train(args, config, train_params, train_file_list):
     use_gpu = args.use_gpu
     model_save_dir = args.model_save_dir
     pretrained_model = args.pretrained_model
-    with_memory_optimization = args.with_mem_opt
 
     devices = os.getenv("CUDA_VISIBLE_DEVICES") or ""
     devices_num = len(devices.split(","))
@@ -165,9 +163,6 @@ def train(args, config, train_params, train_file_list):
         main_prog = train_prog,
         startup_prog = startup_prog,
         args=args)
-
-    if with_memory_optimization:
-        fluid.memory_optimize(train_prog)
 
     place = fluid.CUDAPlace(0) if use_gpu else fluid.CPUPlace()
     exe = fluid.Executor(place)

--- a/PaddleCV/human_pose_estimation/test.py
+++ b/PaddleCV/human_pose_estimation/test.py
@@ -34,7 +34,6 @@ add_arg('batch_size',       int,   32,                  "Minibatch size.")
 add_arg('dataset',          str,   'mpii',              "Dataset")
 add_arg('use_gpu',          bool,  True,                "Whether to use GPU or not.")
 add_arg('kp_dim',           int,   16,                  "Class number.")
-add_arg('with_mem_opt',     bool,  True,               "Whether to use memory optimization or not.")
 add_arg('checkpoint',       str,   None,                "Whether to resume checkpoint.")
 add_arg('flip_test',        bool,  True,                "Flip test")
 add_arg('shift_heatmap',    bool,  True,                "Shift heatmap")
@@ -70,10 +69,6 @@ def test(args):
 
     # Output
     output = model.net(input=image, target=None, target_weight=None)
-
-    if args.with_mem_opt:
-        fluid.memory_optimize(fluid.default_main_program(),
-                              skip_opt_set=[output.name])
 
     place = fluid.CUDAPlace(0) if args.use_gpu else fluid.CPUPlace()
     exe = fluid.Executor(place)

--- a/PaddleCV/human_pose_estimation/train.py
+++ b/PaddleCV/human_pose_estimation/train.py
@@ -38,7 +38,6 @@ add_arg('num_epochs',       int,   140,                          "Number of epoc
 add_arg('total_images',     int,   144406,                       "Training image number.")
 add_arg('kp_dim',           int,   16,                           "Class number.")
 add_arg('model_save_dir',   str,   "output",                     "Model save directory")
-add_arg('with_mem_opt',     bool,  True,                         "Whether to use memory optimization or not.")
 add_arg('pretrained_model', str,   "pretrained/resnet_50/115",   "Whether to use pretrained model.")
 add_arg('checkpoint',       str,   None,                         "Whether to resume checkpoint.")
 add_arg('lr',               float, 0.001,                        "Set learning rate.")
@@ -123,10 +122,6 @@ def train(args):
     # Initialize optimizer
     optimizer = optimizer_setting(args, params)
     optimizer.minimize(loss)
-
-    if args.with_mem_opt:
-        fluid.memory_optimize(fluid.default_main_program(),
-                              skip_opt_set=[loss.name, output.name, target.name])
 
     place = fluid.CUDAPlace(0) if args.use_gpu else fluid.CPUPlace()
     exe = fluid.Executor(place)

--- a/PaddleCV/human_pose_estimation/val.py
+++ b/PaddleCV/human_pose_estimation/val.py
@@ -38,7 +38,6 @@ add_arg('use_gpu',          bool,  True,                "Whether to use GPU or n
 add_arg('num_epochs',       int,   140,                 "Number of epochs.")
 add_arg('total_images',     int,   144406,              "Training image number.")
 add_arg('kp_dim',           int,   16,                  "Class number.")
-add_arg('with_mem_opt',     bool,  True,                "Whether to use memory optimization or not.")
 add_arg('pretrained_model', str,   None,                "Whether to use pretrained model.")
 add_arg('checkpoint',       str,   None,                "Whether to resume checkpoint.")
 add_arg('lr',               float, 0.001,               "Set learning rate.")
@@ -97,10 +96,6 @@ def valid(args):
     params["learning_strategy"] = {}
     params["learning_strategy"]["batch_size"] = args.batch_size
     params["learning_strategy"]["name"] = args.lr_strategy
-
-    if args.with_mem_opt:
-        fluid.memory_optimize(fluid.default_main_program(),
-                              skip_opt_set=[loss.name, output.name, target.name])
 
     place = fluid.CUDAPlace(0) if args.use_gpu else fluid.CPUPlace()
     exe = fluid.Executor(place)

--- a/PaddleCV/image_classification/eval.py
+++ b/PaddleCV/image_classification/eval.py
@@ -38,7 +38,6 @@ add_arg('batch_size',       int,  256,                 "Minibatch size.")
 add_arg('use_gpu',          bool, True,                "Whether to use GPU or not.")
 add_arg('class_dim',        int,  1000,                "Class number.")
 add_arg('image_shape',      str,  "3,224,224",         "Input image size")
-add_arg('with_mem_opt',     bool, True,                "Whether to use memory optimization or not.")
 add_arg('pretrained_model', str,  None,                "Whether to use pretrained model.")
 add_arg('model',            str,  "SE_ResNeXt50_32x4d", "Set the network to use.")
 add_arg('resize_short_size', int, 256,                "Set resize short size")
@@ -50,7 +49,6 @@ def eval(args):
     class_dim = args.class_dim
     model_name = args.model
     pretrained_model = args.pretrained_model
-    with_memory_optimization = args.with_mem_opt
     image_shape = [int(m) for m in args.image_shape.split(",")]
 
     model_list = [m for m in dir(models) if "__" not in m]
@@ -86,9 +84,6 @@ def eval(args):
     test_program = fluid.default_main_program().clone(for_test=True)
 
     fetch_list = [avg_cost.name, acc_top1.name, acc_top5.name]
-    if with_memory_optimization:
-        fluid.memory_optimize(
-            fluid.default_main_program(), skip_opt_set=set(fetch_list))
 
     place = fluid.CUDAPlace(0) if args.use_gpu else fluid.CPUPlace()
     exe = fluid.Executor(place)

--- a/PaddleCV/image_classification/fast_imagenet/train.py
+++ b/PaddleCV/image_classification/fast_imagenet/train.py
@@ -55,7 +55,6 @@ def parse_args():
     add_arg('num_threads',      int,    8,                  "Use num_threads to run the fluid program.")
     add_arg('reduce_strategy',  str,    "allreduce",        "Choose from reduce or allreduce.")
     add_arg('log_period',       int,    30,                 "Print period, defualt is 5.")
-    add_arg('memory_optimize',  bool,   True,               "Whether to enable memory optimize.")
     add_arg('best_acc5',        float,  0.93,               "The best acc5, default is 93%.")
     # yapf: enable
     args = parser.parse_args()
@@ -174,9 +173,6 @@ def build_program(args,
                                                       params_grads, main_prog)
                 else:
                     optimizer.minimize(avg_cost)
-
-                if args.memory_optimize:
-                    fluid.memory_optimize(main_prog, skip_grads=True)
 
     return avg_cost, optimizer, [batch_acc1, batch_acc5], pyreader
 

--- a/PaddleCV/image_classification/infer.py
+++ b/PaddleCV/image_classification/infer.py
@@ -37,7 +37,6 @@ add_arg = functools.partial(add_arguments, argparser=parser)
 add_arg('use_gpu',          bool, True,                 "Whether to use GPU or not.")
 add_arg('class_dim',        int,  1000,                 "Class number.")
 add_arg('image_shape',      str,  "3,224,224",          "Input image size")
-add_arg('with_mem_opt',     bool, True,                 "Whether to use memory optimization or not.")
 add_arg('pretrained_model', str,  None,                 "Whether to use pretrained model.")
 add_arg('model',            str,  "SE_ResNeXt50_32x4d", "Set the network to use.")
 add_arg('save_inference',   bool, False,                 "Whether to save inference model or not")
@@ -51,7 +50,6 @@ def infer(args):
     model_name = args.model
     save_inference = args.save_inference
     pretrained_model = args.pretrained_model
-    with_memory_optimization = args.with_mem_opt
     image_shape = [int(m) for m in args.image_shape.split(",")]
     model_list = [m for m in dir(models) if "__" not in m]
     assert model_name in model_list, "{} is not in lists: {}".format(args.model,
@@ -70,9 +68,6 @@ def infer(args):
     test_program = fluid.default_main_program().clone(for_test=True)
 
     fetch_list = [out.name]
-    if with_memory_optimization and not save_inference:
-        fluid.memory_optimize(
-            fluid.default_main_program(), skip_opt_set=set(fetch_list))
 
     place = fluid.CUDAPlace(0) if args.use_gpu else fluid.CPUPlace()
     exe = fluid.Executor(place)

--- a/PaddleCV/image_classification/train.py
+++ b/PaddleCV/image_classification/train.py
@@ -65,7 +65,6 @@ add_arg('num_epochs',       int,   120,                  "number of epochs.")
 add_arg('class_dim',        int,   1000,                 "Class number.")
 add_arg('image_shape',      str,   "3,224,224",          "input image size")
 add_arg('model_save_dir',   str,   "output",             "model save directory")
-add_arg('with_mem_opt',     bool,  False,                 "Whether to use memory optimization or not.")
 add_arg('with_inplace',     bool,  True,                 "Whether to use inplace memory optimization.")
 add_arg('pretrained_model', str,   None,                 "Whether to use pretrained model.")
 add_arg('checkpoint',       str,   None,                 "Whether to resume checkpoint.")
@@ -347,7 +346,6 @@ def train(args):
     model_name = args.model
     checkpoint = args.checkpoint
     pretrained_model = args.pretrained_model
-    with_memory_optimization = args.with_mem_opt
     model_save_dir = args.model_save_dir
     use_mixup = args.use_mixup
 
@@ -386,10 +384,6 @@ def train(args):
                      args=args)
     test_py_reader, test_cost, test_acc1, test_acc5 = b_out_test[0],b_out_test[1],b_out_test[2],b_out_test[3]
     test_prog = test_prog.clone(for_test=True)
-
-    if with_memory_optimization:
-        fluid.memory_optimize(train_prog)
-        fluid.memory_optimize(test_prog)
 
     gpu_id = int(os.environ.get('FLAGS_selected_gpus', 0))
     place = fluid.CUDAPlace(gpu_id) if args.use_gpu else fluid.CPUPlace()

--- a/PaddleCV/metric_learning/eval.py
+++ b/PaddleCV/metric_learning/eval.py
@@ -37,7 +37,6 @@ add_arg('embedding_size', int, 0, "Embedding size.")
 add_arg('batch_size', int, 10, "Minibatch size.")
 add_arg('image_shape', str, "3,224,224", "Input image size.")
 add_arg('use_gpu', bool, True, "Whether to use GPU or not.")
-add_arg('with_mem_opt', bool, False, "Whether to use memory optimization or not.")
 add_arg('pretrained_model', str, None, "Whether to use pretrained model.")
 # yapf: enable
 
@@ -48,7 +47,6 @@ def eval(args):
     # parameters from arguments
     model_name = args.model
     pretrained_model = args.pretrained_model
-    with_memory_optimization = args.with_mem_opt
     image_shape = [int(m) for m in args.image_shape.split(",")]
 
     assert model_name in model_list, "{} is not in lists: {}".format(args.model,
@@ -62,9 +60,6 @@ def eval(args):
     out = model.net(input=image, embedding_size=args.embedding_size)
 
     test_program = fluid.default_main_program().clone(for_test=True)
-
-    if with_memory_optimization:
-        fluid.memory_optimize(fluid.default_main_program())
 
     place = fluid.CUDAPlace(0) if args.use_gpu else fluid.CPUPlace()
     exe = fluid.Executor(place)

--- a/PaddleCV/metric_learning/infer.py
+++ b/PaddleCV/metric_learning/infer.py
@@ -36,7 +36,6 @@ add_arg('embedding_size', int, 0, "Embedding size.")
 add_arg('batch_size', int, 1, "Minibatch size.")
 add_arg('image_shape', str, "3,224,224", "Input image size.")
 add_arg('use_gpu', bool, True, "Whether to use GPU or not.")
-add_arg('with_mem_opt', bool, False, "Whether to use memory optimization or not.")
 add_arg('pretrained_model', str, None, "Whether to use pretrained model.")
 # yapf: enable
 
@@ -47,7 +46,6 @@ def infer(args):
     # parameters from arguments
     model_name = args.model
     pretrained_model = args.pretrained_model
-    with_memory_optimization = args.with_mem_opt
     image_shape = [int(m) for m in args.image_shape.split(",")]
 
     assert model_name in model_list, "{} is not in lists: {}".format(args.model,
@@ -60,9 +58,6 @@ def infer(args):
     out = model.net(input=image, embedding_size=args.embedding_size)
 
     test_program = fluid.default_main_program().clone(for_test=True)
-
-    if with_memory_optimization:
-        fluid.memory_optimize(fluid.default_main_program())
 
     place = fluid.CUDAPlace(0) if args.use_gpu else fluid.CPUPlace()
     exe = fluid.Executor(place)

--- a/PaddleCV/metric_learning/train_elem.py
+++ b/PaddleCV/metric_learning/train_elem.py
@@ -51,7 +51,6 @@ add_arg('display_iter_step', int, 10, "display_iter_step.")
 add_arg('test_iter_step', int, 1000, "test_iter_step.")
 add_arg('save_iter_step', int, 1000, "save_iter_step.")
 add_arg('use_gpu', bool, True, "Whether to use GPU or not.")
-add_arg('with_mem_opt', bool, True, "Whether to use memory optimization or not.")
 add_arg('pretrained_model', str, None, "Whether to use pretrained model.")
 add_arg('checkpoint', str, None, "Whether to resume checkpoint.")
 add_arg('model_save_dir', str, "output", "model save directory")
@@ -178,9 +177,6 @@ def train_async(args):
 
     train_fetch_list = [global_lr.name, train_cost.name, train_acc1.name, train_acc5.name]
     test_fetch_list = [test_feas.name]
-
-    if args.with_mem_opt:
-        fluid.memory_optimize(train_prog, skip_opt_set=set(train_fetch_list))
 
     place = fluid.CUDAPlace(0) if args.use_gpu else fluid.CPUPlace()
     exe = fluid.Executor(place)

--- a/PaddleCV/metric_learning/train_pair.py
+++ b/PaddleCV/metric_learning/train_pair.py
@@ -53,7 +53,6 @@ add_arg('display_iter_step', int, 10, "display_iter_step.")
 add_arg('test_iter_step', int, 5000, "test_iter_step.")
 add_arg('save_iter_step', int, 5000, "save_iter_step.")
 add_arg('use_gpu', bool, True, "Whether to use GPU or not.")
-add_arg('with_mem_opt', bool, True, "Whether to use memory optimization or not.")
 add_arg('pretrained_model', str, None, "Whether to use pretrained model.")
 add_arg('checkpoint', str, None, "Whether to resume checkpoint.")
 add_arg('model_save_dir', str, "output", "model save directory")
@@ -179,9 +178,6 @@ def train_async(args):
 
     train_fetch_list = [global_lr.name, train_cost.name, train_feas.name, train_label.name]
     test_fetch_list = [test_feas.name]
-
-    if args.with_mem_opt:
-        fluid.memory_optimize(train_prog, skip_opt_set=set(train_fetch_list))
 
     place = fluid.CUDAPlace(0) if args.use_gpu else fluid.CPUPlace()
     exe = fluid.Executor(place)

--- a/PaddleCV/rcnn/train.py
+++ b/PaddleCV/rcnn/train.py
@@ -105,7 +105,6 @@ def train():
     for var in fetch_list:
         var.persistable = True
 
-    #fluid.memory_optimize(fluid.default_main_program(), skip_opt_set=set(fetch_list))
     gpu_id = int(os.environ.get('FLAGS_selected_gpus', 0))
     place = fluid.CUDAPlace(gpu_id) if cfg.use_gpu else fluid.CPUPlace()
     exe = fluid.Executor(place)

--- a/PaddleNLP/Research/ACL2018-DAM/main.py
+++ b/PaddleNLP/Research/ACL2018-DAM/main.py
@@ -145,13 +145,6 @@ def train(args):
                     decay_rate=0.9,
                     staircase=True))
             optimizer.minimize(loss)
-            print("begin memory optimization ...")
-            print(
-                time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(time.time())))
-            fluid.memory_optimize(train_program)
-            print("end memory optimization ...")
-            print(
-                time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(time.time())))
 
     test_program = fluid.Program()
     test_startup = fluid.Program()
@@ -382,12 +375,6 @@ def test(args):
             decay_rate=0.9,
             staircase=True))
     optimizer.minimize(loss)
-
-    print("begin memory optimization ...")
-    print(time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(time.time())))
-    fluid.memory_optimize(fluid.default_main_program())
-    print("end memory optimization ...")
-    print(time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(time.time())))
 
     if args.use_cuda:
         place = fluid.CUDAPlace(0)

--- a/PaddleNLP/Research/ACL2019-DuConv/generative_paddle/network.py
+++ b/PaddleNLP/Research/ACL2019-DuConv/generative_paddle/network.py
@@ -482,7 +482,6 @@ def train(config):
         print("stage 1")
         optimizer.minimize(final_loss)
 
-    fluid.memory_optimize(main_program)
     opt_var_name_list = optimizer.get_opti_var_name_list()
 
     if config.use_gpu:

--- a/PaddleNLP/Research/ACL2019-JEMT/infer.py
+++ b/PaddleNLP/Research/ACL2019-JEMT/infer.py
@@ -66,11 +66,6 @@ def parse_args():
         help="The delimiter used to split tokens in source or target sentences. "
         "For EN-DE BPE data we provided, use spaces as token delimiter. ")
     parser.add_argument(
-        "--use_mem_opt",
-        type=ast.literal_eval,
-        default=True,
-        help="The flag indicating whether to use memory optimization.")
-    parser.add_argument(
         "--use_py_reader",
         type=ast.literal_eval,
         default=True,
@@ -230,9 +225,6 @@ def fast_infer(args):
 
     # This is used here to set dropout to the test mode.
     infer_program = fluid.default_main_program().clone(for_test=True)
-
-    if args.use_mem_opt:
-        fluid.memory_optimize(infer_program)
 
     if InferTaskConfig.use_gpu:
         place = fluid.CUDAPlace(0)

--- a/PaddleNLP/Research/ACL2019-JEMT/train.py
+++ b/PaddleNLP/Research/ACL2019-JEMT/train.py
@@ -125,11 +125,6 @@ def parse_args():
         help="The flag indicating whether to run the task "
         "for continuous evaluation.")
     parser.add_argument(
-        "--use_mem_opt",
-        type=ast.literal_eval,
-        default=True,
-        help="The flag indicating whether to use memory optimization.")
-    parser.add_argument(
         "--use_py_reader",
         type=ast.literal_eval,
         default=True,
@@ -736,9 +731,6 @@ def train(args):
             else:
                 optimizer = fluid.optimizer.SGD(0.003)
             optimizer.minimize(avg_cost)
-
-    if args.use_mem_opt:
-        fluid.memory_optimize(train_prog)
 
     if args.local:
         logging.info("local start_up:")

--- a/PaddleNLP/Research/NAACL2019-MPM/run_classifier.py
+++ b/PaddleNLP/Research/NAACL2019-MPM/run_classifier.py
@@ -271,12 +271,6 @@ def kfold_program(args, processor, train_examples, dev_examples, test_examples, 
                     use_fp16=args.use_fp16,
                     loss_scaling=args.loss_scaling)
 
-                fluid.memory_optimize(
-                    input_program=train_program,
-                    skip_opt_set=[
-                        loss.name, probs.name, accuracy.name, num_seqs.name
-                    ])
-
         if args.verbose:
             if args.in_tokens:
                 lower_mem, upper_mem, unit = fluid.contrib.memory_usage(
@@ -548,12 +542,6 @@ def train_single(args):
                     scheduler=args.lr_scheduler,
                     use_fp16=args.use_fp16,
                     loss_scaling=args.loss_scaling)
-
-                fluid.memory_optimize(
-                    input_program=train_program,
-                    skip_opt_set=[
-                        loss.name, probs.name, accuracy.name, num_seqs.name
-                    ])
 
         if args.verbose:
             if args.in_tokens:

--- a/PaddleNLP/unarchived/deep_attention_matching_net/test_and_evaluate.py
+++ b/PaddleNLP/unarchived/deep_attention_matching_net/test_and_evaluate.py
@@ -145,8 +145,6 @@ def test(args):
             staircase=True))
     optimizer.minimize(loss)
 
-    fluid.memory_optimize(fluid.default_main_program())
-
     if args.use_cuda:
         place = fluid.CUDAPlace(0)
         dev_count = fluid.core.get_cuda_device_count()

--- a/PaddleNLP/unarchived/deep_attention_matching_net/train_and_evaluate.py
+++ b/PaddleNLP/unarchived/deep_attention_matching_net/train_and_evaluate.py
@@ -216,9 +216,6 @@ def train(args):
                     decay_rate=0.9,
                     staircase=True))
             optimizer.minimize(loss)
-            print("begin memory optimization ...")
-            fluid.memory_optimize(train_program)
-            print("end memory optimization ...")
 
     test_program = fluid.Program()
     test_startup = fluid.Program()

--- a/PaddleNLP/unarchived/neural_machine_translation/transformer/infer.py
+++ b/PaddleNLP/unarchived/neural_machine_translation/transformer/infer.py
@@ -57,11 +57,6 @@ def parse_args():
         help="The delimiter used to split tokens in source or target sentences. "
         "For EN-DE BPE data we provided, use spaces as token delimiter. ")
     parser.add_argument(
-        "--use_mem_opt",
-        type=ast.literal_eval,
-        default=True,
-        help="The flag indicating whether to use memory optimization.")
-    parser.add_argument(
         "--use_py_reader",
         type=ast.literal_eval,
         default=True,
@@ -211,9 +206,6 @@ def fast_infer(args):
 
     # This is used here to set dropout to the test mode.
     infer_program = fluid.default_main_program().clone(for_test=True)
-
-    if args.use_mem_opt:
-        fluid.memory_optimize(infer_program)
 
     if InferTaskConfig.use_gpu:
         place = fluid.CUDAPlace(0)

--- a/PaddleNLP/unarchived/neural_machine_translation/transformer/profile.py
+++ b/PaddleNLP/unarchived/neural_machine_translation/transformer/profile.py
@@ -82,11 +82,6 @@ def parse_args():
         help="The delimiter used to split tokens in source or target sentences. "
         "For EN-DE BPE data we provided, use spaces as token delimiter.")
     parser.add_argument(
-        "--use_mem_opt",
-        type=ast.literal_eval,
-        default=True,
-        help="The flag indicating whether to use memory optimization.")
-    parser.add_argument(
         "--use_py_reader",
         type=ast.literal_eval,
         default=True,
@@ -161,9 +156,6 @@ def main(args):
                 beta2=TrainTaskConfig.beta2,
                 epsilon=TrainTaskConfig.eps)
             optimizer.minimize(avg_cost)
-
-    if args.use_mem_opt:
-        fluid.memory_optimize(train_prog)
 
     if TrainTaskConfig.use_gpu:
         place = fluid.CUDAPlace(0)

--- a/PaddleNLP/unarchived/neural_machine_translation/transformer/train.py
+++ b/PaddleNLP/unarchived/neural_machine_translation/transformer/train.py
@@ -114,11 +114,6 @@ def parse_args():
         help="The flag indicating whether to run the task "
         "for continuous evaluation.")
     parser.add_argument(
-        "--use_mem_opt",
-        type=ast.literal_eval,
-        default=True,
-        help="The flag indicating whether to use memory optimization.")
-    parser.add_argument(
         "--use_py_reader",
         type=ast.literal_eval,
         default=True,
@@ -681,9 +676,6 @@ def train(args):
             else:
                 optimizer = fluid.optimizer.SGD(0.003)
             optimizer.minimize(avg_cost)
-
-    if args.use_mem_opt:
-        fluid.memory_optimize(train_prog)
 
     if args.local:
         logging.info("local start_up:")

--- a/PaddleSpeech/DeepASR/train.py
+++ b/PaddleSpeech/DeepASR/train.py
@@ -174,7 +174,6 @@ def train(args):
                     decay_rate=1 / 1.2,
                     staircase=True))
             optimizer.minimize(avg_cost)
-            fluid.memory_optimize(train_program)
 
     test_program = fluid.Program()
     test_startup = fluid.Program()


### PR DESCRIPTION
Interface `fluid.memory_optimize` has been deprecated in Paddle since [PR18983](https://github.com/PaddlePaddle/Paddle/pull/18983).

So this PR tries to remove all usages of empty interface `fluid.memory_optimize` in models.