### PR TITLE
fix train on VOC on multi-GPU hang

### DIFF
--- a/PaddleCV/PaddleDetection/ppdet/utils/eval_utils.py
+++ b/PaddleCV/PaddleDetection/ppdet/utils/eval_utils.py
@@ -48,7 +48,6 @@ def parse_fetches(fetches, prog=None, extra_keys=None):
         for k in extra_keys:
             try:
                 v = fluid.framework._get_var(k, prog)
-                v.persistable = True
                 keys.append(k)
                 values.append(v.name)
             except Exception:

--- a/PaddleCV/PaddleDetection/tools/train.py
+++ b/PaddleCV/PaddleDetection/tools/train.py
@@ -127,12 +127,9 @@ def main():
         if cfg.metric == 'COCO':
             extra_keys = ['im_info', 'im_id', 'im_shape']
         if cfg.metric == 'VOC':
-            extra_keys = ['is_difficult']
+            extra_keys = ['gt_box', 'gt_label', 'is_difficult']
         eval_keys, eval_values, eval_cls = parse_fetches(fetches, eval_prog,
                                                          extra_keys)
-        if cfg.metric == 'VOC':
-            eval_keys += ['gt_box', 'gt_label']
-            eval_values += ['gt_box', 'gt_label']
 
     # compile program for multi-devices
     build_strategy = fluid.BuildStrategy()

--- a/PaddleCV/PaddleDetection/tools/train.py
+++ b/PaddleCV/PaddleDetection/tools/train.py
@@ -127,9 +127,12 @@ def main():
         if cfg.metric == 'COCO':
             extra_keys = ['im_info', 'im_id', 'im_shape']
         if cfg.metric == 'VOC':
-            extra_keys = ['gt_box', 'gt_label', 'is_difficult']
+            extra_keys = ['is_difficult']
         eval_keys, eval_values, eval_cls = parse_fetches(fetches, eval_prog,
                                                          extra_keys)
+        if cfg.metric == 'VOC':
+            eval_keys += ['gt_box', 'gt_label']
+            eval_values += ['gt_box', 'gt_label']
 
     # compile program for multi-devices
     build_strategy = fluid.BuildStrategy()


### PR DESCRIPTION
**fix train on VOC on multi-GPU hang**
**问题表现：** 多卡训练使用VOC数据集train --eval时，第一个snapshot没有问题，eval完第一个snapshot后会hang住
**定位情况：** 定位为pyreader不能正确读取数据，其中gt_box, gt_label为模型的输入，并在train中会被网络用到，eval中需要直接fetch这两个Variable，若在eval_prog里面将其置为persistable，再次train时pyreader无法正确读取数据，该情况须知会框架定位具体原因，是否需要修复？
**解决方案：**
1. parse_fetch中不将extra_keys设为persistable，须确认使用gc是否会有问题
2. 修改voc_eval中逻辑，不从模型input中获取gt_box, gt_label, 类似coco_eval一样，传进来anno_path, 在voc_eval中重新读取数据集gt

**方案2潜在风险:**
若通过anno_path的方式，须通过im_id匹配pred和gt，标准VOC数据集中image的名称有`009247`和`2008_002152`两种形式，其中第二种形式无法转换成int类型的im_id, 但基于ppdet目前VOC的分划，val部分的image名称全为第一种形式，可以转换成int类型的im_id。**若用户自定义数据集，则需要要求用户的image名称均为数字类型，有此局限性**

**结论：** 
gc下若未开启inplace，memory_opt，可不设置persistable，采用方法1

**测试：**
python2/3 train eval精度正确