### PR TITLE
Set build_strategy.enable_inplace = True in models

### DIFF
--- a/PaddleCV/PaddleDetection/tools/train.py
+++ b/PaddleCV/PaddleDetection/tools/train.py
@@ -133,7 +133,6 @@ def main():
 
     # compile program for multi-devices
     build_strategy = fluid.BuildStrategy()
-    build_strategy.enable_inplace = False
     sync_bn = getattr(model.backbone, 'norm_type', None) == 'sync_bn'
     # only enable sync_bn in multi GPU devices
     build_strategy.sync_batch_norm = sync_bn and devices_num > 1 and cfg.use_gpu

--- a/PaddleCV/PaddleGAN/cycle_gan/train.py
+++ b/PaddleCV/PaddleGAN/cycle_gan/train.py
@@ -189,8 +189,6 @@ def train(args):
     losses = [[], []]
     t_time = 0
     build_strategy = fluid.BuildStrategy()
-    build_strategy.enable_inplace = False
-    build_strategy.memory_optimize = False
 
     exec_strategy = fluid.ExecutionStrategy()
     exec_strategy.num_threads = 1

--- a/PaddleCV/PaddleGAN/trainer/AttGAN.py
+++ b/PaddleCV/PaddleGAN/trainer/AttGAN.py
@@ -316,7 +316,6 @@ class AttGAN(object):
 
         ### memory optim
         build_strategy = fluid.BuildStrategy()
-        build_strategy.enable_inplace = False
 
         gen_trainer_program = fluid.CompiledProgram(
             gen_trainer.program).with_data_parallel(

--- a/PaddleCV/PaddleGAN/trainer/Pix2pix.py
+++ b/PaddleCV/PaddleGAN/trainer/Pix2pix.py
@@ -245,7 +245,6 @@ class Pix2pix(object):
 
         ### memory optim
         build_strategy = fluid.BuildStrategy()
-        build_strategy.enable_inplace = False
 
         gen_trainer_program = fluid.CompiledProgram(
             gen_trainer.program).with_data_parallel(

--- a/PaddleCV/PaddleGAN/trainer/STGAN.py
+++ b/PaddleCV/PaddleGAN/trainer/STGAN.py
@@ -328,7 +328,6 @@ class STGAN(object):
 
         ### memory optim
         build_strategy = fluid.BuildStrategy()
-        build_strategy.enable_inplace = False
 
         gen_trainer_program = fluid.CompiledProgram(
             gen_trainer.program).with_data_parallel(

--- a/PaddleCV/PaddleGAN/trainer/StarGAN.py
+++ b/PaddleCV/PaddleGAN/trainer/StarGAN.py
@@ -294,7 +294,6 @@ class StarGAN(object):
 
         ### memory optim
         build_strategy = fluid.BuildStrategy()
-        build_strategy.enable_inplace = False
 
         gen_trainer_program = fluid.CompiledProgram(
             gen_trainer.program).with_data_parallel(

--- a/PaddleCV/PaddleVideo/train.py
+++ b/PaddleCV/PaddleVideo/train.py
@@ -171,7 +171,6 @@ def train(args):
     build_strategy.enable_inplace = True
     if args.model_name in ['CTCN']:
         build_strategy.enable_sequential_execution = True
-    #build_strategy.memory_optimize = True
 
     compiled_train_prog = fluid.compiler.CompiledProgram(
         train_prog).with_data_parallel(

--- a/PaddleCV/deeplabv3+/train.py
+++ b/PaddleCV/deeplabv3+/train.py
@@ -200,7 +200,6 @@ build_strategy = fluid.BuildStrategy()
 if args.memory_optimize:
     build_strategy.fuse_relu_depthwise_conv = True
     build_strategy.enable_inplace = True
-    build_strategy.memory_optimize = True
 
 place = fluid.CPUPlace()
 if args.use_gpu:

--- a/PaddleCV/image_classification/legacy/dist_train/dist_train.py
+++ b/PaddleCV/image_classification/legacy/dist_train/dist_train.py
@@ -284,7 +284,6 @@ def train_parallel(args):
     strategy.num_iteration_per_drop_scope = 30
 
     build_strategy = fluid.BuildStrategy()
-    build_strategy.enable_inplace = False
     build_strategy.memory_optimize = False
     build_strategy.enable_sequential_execution = bool(
         args.enable_sequential_execution)

--- a/PaddleCV/ssd/train.py
+++ b/PaddleCV/ssd/train.py
@@ -210,7 +210,6 @@ def train(args,
         loss.persistable = True
         build_strategy = fluid.BuildStrategy()
         build_strategy.enable_inplace = True
-        build_strategy.memory_optimize = True
         train_exe = fluid.ParallelExecutor(main_program=train_prog,
             use_cuda=use_gpu, loss_name=loss.name, build_strategy=build_strategy)
 


### PR DESCRIPTION
`build_strategy.enable_inplace` is True by default since [Paddle17911](https://github.com/PaddlePaddle/Paddle/pull/17911), and it helps to save memory usages of models. What's more, it is not necessary to set `fetch_var.persistable = True` anymore when `build_strategy.enable_inplace=True`. This PR removes `build_strategy.enable_inplace = False` in models.