### PR TITLE
Make exec_strategy.num_iteration_per_drop_scope = 1 in detection models

### DIFF
--- a/PaddleCV/PaddleDetection/tools/train.py
+++ b/PaddleCV/PaddleDetection/tools/train.py
@@ -138,9 +138,17 @@ def main():
     sync_bn = getattr(model.backbone, 'norm_type', None) == 'sync_bn'
     # only enable sync_bn in multi GPU devices
     build_strategy.sync_batch_norm = sync_bn and devices_num > 1 and cfg.use_gpu
+
+    exec_strategy = fluid.ExecutionStrategy()
+    # iteration number when CompiledProgram tries to drop local execution scopes.
+    # Set it to be 1 to save memory usages, so that unused variables in
+    # local execution scopes can be deleted after each iteration.
+    exec_strategy.num_iteration_per_drop_scope = 1
+
     train_compile_program = fluid.compiler.CompiledProgram(
         train_prog).with_data_parallel(
-            loss_name=loss.name, build_strategy=build_strategy)
+            loss_name=loss.name, build_strategy=build_strategy,
+            exec_strategy=exec_strategy)
     if FLAGS.eval:
         eval_compile_program = fluid.compiler.CompiledProgram(eval_prog)
 


### PR DESCRIPTION
The default value of `exec_strategy.num_iteration_per_drop_scope` is 100 since [#Paddle19075](https://github.com/PaddlePaddle/Paddle/pull/19075). But in detection models such as `mask_rcnn_r101_fpn_1x.yml`, the garbages in scopes may be larger than 4G. This PR sets `exec_strategy.num_iteration_per_drop_scope` to be 1 to avoid memory leak.

![42540804212a633682f2bf3eacace728](https://user-images.githubusercontent.com/32832641/64587566-686bd100-d3d2-11e9-812f-9a236164dc49.jpg)
