### PR TITLE
Fix the test program clone position error in sequence_tagging_for_ner model

### DIFF
--- a/fluid/PaddleNLP/sequence_tagging_for_ner/train.py
+++ b/fluid/PaddleNLP/sequence_tagging_for_ner/train.py
@@ -61,9 +61,6 @@ def main(train_data_file,
     avg_cost, feature_out, word, mark, target = ner_net(
         word_dict_len, label_dict_len, parallel)
 
-    sgd_optimizer = fluid.optimizer.SGD(learning_rate=1e-3)
-    sgd_optimizer.minimize(avg_cost)
-
     crf_decode = fluid.layers.crf_decoding(
         input=feature_out, param_attr=fluid.ParamAttr(name='crfw'))
 
@@ -77,6 +74,8 @@ def main(train_data_file,
 
     inference_program = fluid.default_main_program().clone(for_test=True)
     test_fetch_list = [num_infer_chunks, num_label_chunks, num_correct_chunks]
+    sgd_optimizer = fluid.optimizer.SGD(learning_rate=1e-3)
+    sgd_optimizer.minimize(avg_cost)
 
     if "CE_MODE_X" not in os.environ:
         train_reader = paddle.batch(


### PR DESCRIPTION
There are two error in this old version sequence_tagging_for_ner model:
1. the `optimizer.minimize` is called before `test_program.clone`
2. the `optimizer.minimize` is called before `crf_decoding`

these two error have been fixed in new branch, this pr just for sync the fix.