### PR TITLE
refine auto download logs

### DIFF
--- a/PaddleCV/PaddleDetection/ppdet/utils/download.py
+++ b/PaddleCV/PaddleDetection/ppdet/utils/download.py
@@ -81,7 +81,7 @@ def get_dataset_path(path, annotation, image_dir):
     if _dataset_exists(path, annotation, image_dir):
         return path
 
-    logger.info("Dataset {} not exists, try searching {} or "
+    logger.info("Dataset {} not valid for reason above, try searching {} or "
                 "downloading dataset...".format(
                     osp.realpath(path), DATASET_HOME))
 
@@ -125,7 +125,10 @@ def get_dataset_path(path, annotation, image_dir):
             return data_dir
 
     # not match any dataset in DATASETS
-    raise ValueError("{} not exists or unknow dataset type".format(path))
+    raise ValueError("Dataset {} not valid and cannot parse dataset type "
+                     "'{}' for automaticly downloading, automaticly "
+                     "downloading only support 'voc' and 'coco' "
+                     "currently".format(path, osp.split(path)[-1]))
 
 
 def get_path(url, root_dir, md5sum=None):
@@ -171,20 +174,23 @@ def _dataset_exists(path, annotation, image_dir):
     Check if user define dataset exists
     """
     if not osp.exists(path):
-        logger.info("Config dataset_dir {} not exits".format(path))
+        logger.info("Config dataset_dir {} not exits, "
+                "dataset config is not valid".format(path))
         return False
 
     if annotation:
         annotation_path = osp.join(path, annotation)
         if not osp.isfile(annotation_path):
             logger.info("Config annotation {} is not a "
-                        "file".format(annotation_path))
+                        "file, dataset config is not "
+                        "valid".format(annotation_path))
             return False
     if image_dir:
         image_path = osp.join(path, image_dir)
         if not osp.isdir(image_path):
             logger.info("Config image_dir {} is not a "
-                        "directory".format(image_path))
+                        "directory, dataset config is not "
+                        "valid".format(image_path))
             return False
     return True
 

--- a/PaddleCV/PaddleDetection/ppdet/utils/download.py
+++ b/PaddleCV/PaddleDetection/ppdet/utils/download.py
@@ -126,7 +126,7 @@ def get_dataset_path(path, annotation, image_dir):
 
     # not match any dataset in DATASETS
     raise ValueError("Dataset {} is not valid and cannot parse dataset type "
-                     "'{}' for automaticly downloading, which only support "
+                     "'{}' for automaticly downloading, which only supports "
                      "'voc' and 'coco' currently".format(path, osp.split(path)[-1]))
 
 

--- a/PaddleCV/PaddleDetection/ppdet/utils/download.py
+++ b/PaddleCV/PaddleDetection/ppdet/utils/download.py
@@ -81,7 +81,7 @@ def get_dataset_path(path, annotation, image_dir):
     if _dataset_exists(path, annotation, image_dir):
         return path
 
-    logger.info("Dataset {} not valid for reason above, try searching {} or "
+    logger.info("Dataset {} is not valid for reason above, try searching {} or "
                 "downloading dataset...".format(
                     osp.realpath(path), DATASET_HOME))
 
@@ -125,10 +125,9 @@ def get_dataset_path(path, annotation, image_dir):
             return data_dir
 
     # not match any dataset in DATASETS
-    raise ValueError("Dataset {} not valid and cannot parse dataset type "
-                     "'{}' for automaticly downloading, automaticly "
-                     "downloading only support 'voc' and 'coco' "
-                     "currently".format(path, osp.split(path)[-1]))
+    raise ValueError("Dataset {} is not valid and cannot parse dataset type "
+                     "'{}' for automaticly downloading, which only support "
+                     "'voc' and 'coco' currently".format(path, osp.split(path)[-1]))
 
 
 def get_path(url, root_dir, md5sum=None):
@@ -174,7 +173,7 @@ def _dataset_exists(path, annotation, image_dir):
     Check if user define dataset exists
     """
     if not osp.exists(path):
-        logger.info("Config dataset_dir {} not exits, "
+        logger.info("Config dataset_dir {} is not exits, "
                 "dataset config is not valid".format(path))
         return False
 


### PR DESCRIPTION
**refine auto download logs**
refine logs like
```
2019-09-16 10:03:43,953-INFO: Config dataset_dir dataset/test is not exits, dataset config is not valid
2019-09-16 10:03:43,953-INFO: Dataset /paddle/git/models/PaddleCV/PaddleDetection/dataset/test is not valid for reason above, try searching /root/.cache/paddle/dataset or downloading dataset...
Traceback (most recent call last):
  File "tools/train.py", line 285, in <module>
    main()
  File "tools/train.py", line 165, in main
    FLAGS.dataset_dir)
  File "/paddle/git/models/PaddleCV/PaddleDetection/ppdet/data/data_feed.py", line 91, in create_reader
    data_config = _prepare_data_config(feed, args_path)
  File "/paddle/git/models/PaddleCV/PaddleDetection/ppdet/data/data_feed.py", line 52, in _prepare_data_config
    dataset_dir = get_dataset_path(dataset_home, annotation, image_dir)
  File "/paddle/git/models/PaddleCV/PaddleDetection/ppdet/utils/download.py", line 130, in get_dataset_path
    "'voc' and 'coco' currently".format(path, osp.split(path)[-1]))
ValueError: Dataset dataset/test is not valid and cannot parse dataset type 'test' for automaticly downloading, which only supports 'voc' and 'coco' currently
```