### PR TITLE
fix train finish pyreader reset error

### DIFF
--- a/PaddleCV/PaddleDetection/tools/train.py
+++ b/PaddleCV/PaddleDetection/tools/train.py
@@ -244,7 +244,11 @@ def main():
                 logger.info("Best test box ap: {}, in iter: {}".format(
                     best_box_ap_list[0], best_box_ap_list[1]))
 
-    train_pyreader.reset()
+    # try to reset reader and join threads
+    try:
+        train_pyreader.reset()
+    except NotImplementedError as e:
+        logger.warn("Reader reset not defined: {}".format(str(e)))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
**fix train finish pyreader reset error**
`train_pyreader.reset()` will call `reader.reset()`, `MappedDataset` not implement `reset()` currently, which may cause following error:
```
Traceback (most recent call last):
  File "/ssd3/xiege/models/PaddleCV/PaddleDetection/ppdet/data/transform/transformer.py", line 44, in _proxy_method
    return func(*args, **kwargs)
  File "/ssd3/xiege/models/PaddleCV/PaddleDetection/ppdet/data/dataset.py", line 48, in reset
    (self.__class__.__name__))
NotImplementedError: MappedDataset.reset not available
```