### PR TITLE
Fix dygraph model save

### DIFF
--- a/dygraph/mnist/train.py
+++ b/dygraph/mnist/train.py
@@ -175,7 +175,6 @@ def train_mnist(args):
     epoch_num = args.epoch
     BATCH_SIZE = 64
 
-    trainer_count = fluid.dygraph.parallel.Env().nranks
     place = fluid.CUDAPlace(fluid.dygraph.parallel.Env().dev_id) \
         if args.use_data_parallel else fluid.CUDAPlace(0)
     with fluid.dygraph.guard(place):
@@ -241,8 +240,12 @@ def train_mnist(args):
             print("Loss at epoch {} , Test avg_loss is: {}, acc is: {}".format(
                 epoch, test_cost, test_acc))
 
-        fluid.dygraph.save_persistables(mnist.state_dict(), "save_dir")
-        print("checkpoint saved")
+        save_parameters = (not args.use_data_parallel) or (
+            args.use_data_parallel and
+            fluid.dygraph.parallel.Env().local_rank == 0)
+        if save_parameters:
+            fluid.dygraph.save_persistables(mnist.state_dict(), "save_dir")
+            print("checkpoint saved")
 
         inference_mnist()
 

--- a/dygraph/mnist/train.py
+++ b/dygraph/mnist/train.py
@@ -31,7 +31,8 @@ def parse_args():
         "--use_data_parallel",
         type=ast.literal_eval,
         default=False,
-        help="The flag indicating whether to shuffle instances in each pass.")
+        help="The flag indicating whether to use data parallel mode to train the model."
+    )
     parser.add_argument("-e", "--epoch", default=5, type=int, help="set epoch")
     parser.add_argument("--ce", action="store_true", help="run ce")
     args = parser.parse_args()

--- a/dygraph/resnet/train.py
+++ b/dygraph/resnet/train.py
@@ -38,7 +38,8 @@ def parse_args():
         "--use_data_parallel",
         type=ast.literal_eval,
         default=False,
-        help="The flag indicating whether to shuffle instances in each pass.")
+        help="The flag indicating whether to use data parallel mode to train the model."
+    )
     parser.add_argument(
         "-e", "--epoch", default=120, type=int, help="set epoch")
     parser.add_argument(

--- a/dygraph/resnet/train.py
+++ b/dygraph/resnet/train.py
@@ -39,8 +39,10 @@ def parse_args():
         type=ast.literal_eval,
         default=False,
         help="The flag indicating whether to shuffle instances in each pass.")
-    parser.add_argument("-e", "--epoch", default=120, type=int, help="set epoch")
-    parser.add_argument("-b", "--batch_size", default=32, type=int, help="set epoch")
+    parser.add_argument(
+        "-e", "--epoch", default=120, type=int, help="set epoch")
+    parser.add_argument(
+        "-b", "--batch_size", default=32, type=int, help="set epoch")
     parser.add_argument("--ce", action="store_true", help="run ce")
     args = parser.parse_args()
     return args
@@ -48,6 +50,7 @@ def parse_args():
 
 args = parse_args()
 batch_size = args.batch_size
+
 
 def optimizer_setting():
 
@@ -275,7 +278,6 @@ def eval(model, data):
 
 def train_resnet():
     epoch = args.epoch
-    trainer_count = fluid.dygraph.parallel.Env().nranks
     place = fluid.CUDAPlace(fluid.dygraph.parallel.Env().dev_id) \
         if args.use_data_parallel else fluid.CUDAPlace(0)
     with fluid.dygraph.guard(place):
@@ -353,7 +355,6 @@ def train_resnet():
                 optimizer.minimize(avg_loss)
                 resnet.clear_gradients()
 
-
                 total_loss += dy_out
                 total_acc1 += acc_top1.numpy()
                 total_acc5 += acc_top5.numpy()
@@ -373,7 +374,13 @@ def train_resnet():
                    total_acc1 / total_sample, total_acc5 / total_sample))
             resnet.eval()
             eval(resnet, test_reader)
-            fluid.dygraph.save_persistables(resnet.state_dict(), 'resnet_params')
+
+            save_parameters = (not args.use_data_parallel) or (
+                args.use_data_parallel and
+                fluid.dygraph.parallel.Env().local_rank == 0)
+            if save_parameters:
+                fluid.dygraph.save_persistables(resnet.state_dict(),
+                                                'resnet_params')
 
 
 if __name__ == '__main__':

--- a/dygraph/transformer/train.py
+++ b/dygraph/transformer/train.py
@@ -28,7 +28,8 @@ def parse_args():
         "--use_data_parallel",
         type=ast.literal_eval,
         default=False,
-        help="The flag indicating whether to shuffle instances in each pass.")
+        help="The flag indicating whether to use data parallel mode to train the model."
+    )
     args = parser.parse_args()
     return args
 


### PR DESCRIPTION
Currently, data parallel training using dygraph is a multi-process method, so if parameters need to be saved during training, the saving action should only be called in one process.