### PR TITLE
1. fix bug, lstrip --> rstrip

### DIFF
--- a/PaddleRec/ctr/deepfm/data/preprocess.py
+++ b/PaddleRec/ctr/deepfm/data/preprocess.py
@@ -59,7 +59,7 @@ def get_feat_dict():
             for line_idx, line in enumerate(fin):
                 if line_idx % 100000 == 0:
                     print('generating feature dict', line_idx / 45000000)
-                features = line.lstrip('\n').split('\t')
+                features = line.rstrip('\n').split('\t')
                 for idx in categorical_range_:
                     if features[idx] == '': continue
                     feat_cnt.update([features[idx]])


### PR DESCRIPTION
在预处理Criteo数据集的每一行数据时, 作者的本意应该是去掉最后的'\n', 可能由于作者的手误, 使用了lstrip方式, 导致预处理后的数据最后还是保留着'\n', 这里修复成rstrip方式. 经排查, 项目中只有这1处地方使用错误!