### PR TITLE
fix pretrain params download in windows

### DIFF
--- a/PaddleCV/PaddleVideo/models/model.py
+++ b/PaddleCV/PaddleVideo/models/model.py
@@ -23,7 +23,7 @@ except:
 import paddle.fluid as fluid
 from .utils import download, AttrDict
 
-WEIGHT_DIR = os.path.expanduser("~/.paddle/weights")
+WEIGHT_DIR = os.path.join(os.path.expanduser('~'), '.paddle', 'weights')
 
 logger = logging.getLogger(__name__)
 

--- a/PaddleCV/PaddleVideo/models/utils.py
+++ b/PaddleCV/PaddleVideo/models/utils.py
@@ -21,13 +21,13 @@ __all__ = ['decompress', 'download', 'AttrDict']
 
 def decompress(path):
     t = tarfile.open(path)
-    t.extractall(path='/'.join(path.split('/')[:-1]))
+    t.extractall(path=os.path.split(path)[0])
     t.close()
     os.remove(path)
 
 
 def download(url, path):
-    weight_dir = '/'.join(path.split('/')[:-1])
+    weight_dir = os.path.split(path)[0]
     if not os.path.exists(weight_dir):
         os.makedirs(weight_dir)
 


### PR DESCRIPTION
fix pertained model download in windows due to path split '/' and '\\' not match.