### PR TITLE
Fix slim resnet prefix

### DIFF
--- a/PaddleSlim/classification/distillation/compress.py
+++ b/PaddleSlim/classification/distillation/compress.py
@@ -106,15 +106,12 @@ def compress(args):
 
         fluid.io.load_vars(exe, args.pretrained_model, predicate=if_exist)
 
-    val_reader = paddle.batch(
-        reader.val(data_dir='../data/ILSVRC2012'), batch_size=args.batch_size)
+    val_reader = paddle.batch(reader.val(), batch_size=args.batch_size)
     val_feed_list = [('image', image.name), ('label', label.name)]
     val_fetch_list = [('acc_top1', acc_top1.name), ('acc_top5', acc_top5.name)]
 
     train_reader = paddle.batch(
-        reader.train(data_dir='../data/ILSVRC2012'),
-        batch_size=args.batch_size,
-        drop_last=True)
+        reader.train(), batch_size=args.batch_size, drop_last=True)
     train_feed_list = [('image', image.name), ('label', label.name)]
     train_fetch_list = [('loss', avg_cost.name)]
 

--- a/PaddleSlim/classification/models/resnet.py
+++ b/PaddleSlim/classification/models/resnet.py
@@ -29,7 +29,7 @@ class ResNet():
 
     def net(self, input, class_dim=1000, conv1_name='conv1', fc_name=None):
         layers = self.layers
-        prefix_name = self.prefix_name + '_'
+        prefix_name = self.prefix_name if self.prefix_name is '' else self.prefix_name + '_'
         supported_layers = [34, 50, 101, 152]
         assert layers in supported_layers, \
             "supported layers are {} but input layer is {}".format(supported_layers, layers)


### PR DESCRIPTION
1. We do not need to add split character '_' when prefix_name is None.
2. Fix data path in the Slim classification distillation demo.