### PR TITLE
Remove mem opt strategies settings in BuildStrategy

### DIFF
--- a/PaddleCV/PaddleGAN/trainer/CGAN.py
+++ b/PaddleCV/PaddleGAN/trainer/CGAN.py
@@ -111,9 +111,7 @@ class CGAN(object):
             utility.init_checkpoints(self.cfg, exe, g_trainer, "net_G")
             utility.init_checkpoints(self.cfg, exe, d_trainer, "net_D")
 
-        ### memory optim
         build_strategy = fluid.BuildStrategy()
-        build_strategy.enable_inplace = True
 
         g_trainer_program = fluid.CompiledProgram(
             g_trainer.program).with_data_parallel(

--- a/PaddleCV/PaddleGAN/trainer/CycleGAN.py
+++ b/PaddleCV/PaddleGAN/trainer/CycleGAN.py
@@ -279,9 +279,7 @@ class CycleGAN(object):
             utility.init_checkpoints(self.cfg, exe, d_A_trainer, "net_DA")
             utility.init_checkpoints(self.cfg, exe, d_B_trainer, "net_DB")
 
-        ### memory optim
         build_strategy = fluid.BuildStrategy()
-        build_strategy.enable_inplace = True
 
         gen_trainer_program = fluid.CompiledProgram(
             gen_trainer.program).with_data_parallel(

--- a/PaddleCV/PaddleGAN/trainer/DCGAN.py
+++ b/PaddleCV/PaddleGAN/trainer/DCGAN.py
@@ -107,9 +107,7 @@ class DCGAN(object):
             utility.init_checkpoints(self.cfg, exe, g_trainer, "net_G")
             utility.init_checkpoints(self.cfg, exe, d_trainer, "net_D")
 
-        ### memory optim
         build_strategy = fluid.BuildStrategy()
-        build_strategy.enable_inplace = True
 
         g_trainer_program = fluid.CompiledProgram(
             g_trainer.program).with_data_parallel(

--- a/PaddleCV/PaddleGAN/trainer/SPADE.py
+++ b/PaddleCV/PaddleGAN/trainer/SPADE.py
@@ -323,9 +323,7 @@ class SPADE(object):
             utility.init_checkpoints(self.cfg, exe, gen_trainer, "net_G")
             utility.init_checkpoints(self.cfg, exe, dis_trainer, "net_D")
 
-        ### memory optim
         build_strategy = fluid.BuildStrategy()
-        build_strategy.enable_inplace = False
         build_strategy.sync_batch_norm = False
 
         gen_trainer_program = fluid.CompiledProgram(

--- a/PaddleCV/PaddleVideo/train.py
+++ b/PaddleCV/PaddleVideo/train.py
@@ -168,7 +168,6 @@ def train(args):
             train_model.load_pretrain_params(exe, pretrain, train_prog, place)
 
     build_strategy = fluid.BuildStrategy()
-    build_strategy.enable_inplace = True
     if args.model_name in ['CTCN']:
         build_strategy.enable_sequential_execution = True
 

--- a/PaddleCV/deeplabv3+/train.py
+++ b/PaddleCV/deeplabv3+/train.py
@@ -199,7 +199,6 @@ exec_strategy.num_iteration_per_drop_scope = 100
 build_strategy = fluid.BuildStrategy()
 if args.memory_optimize:
     build_strategy.fuse_relu_depthwise_conv = True
-    build_strategy.enable_inplace = True
 
 place = fluid.CPUPlace()
 if args.use_gpu:

--- a/PaddleCV/image_classification/legacy/dist_train/dist_train.py
+++ b/PaddleCV/image_classification/legacy/dist_train/dist_train.py
@@ -284,7 +284,6 @@ def train_parallel(args):
     strategy.num_iteration_per_drop_scope = 30
 
     build_strategy = fluid.BuildStrategy()
-    build_strategy.memory_optimize = False
     build_strategy.enable_sequential_execution = bool(
         args.enable_sequential_execution)
 

--- a/PaddleCV/image_classification/utils/utility.py
+++ b/PaddleCV/image_classification/utils/utility.py
@@ -384,8 +384,6 @@ def best_strategy_compiled(args, program, loss):
         return program
     else:
         build_strategy = fluid.compiler.BuildStrategy()
-        #Feature will be supported in Fluid v1.6
-        #build_strategy.enable_inplace = True
 
         exec_strategy = fluid.ExecutionStrategy()
         exec_strategy.num_threads = fluid.core.get_cuda_device_count()

--- a/PaddleCV/rcnn/train.py
+++ b/PaddleCV/rcnn/train.py
@@ -119,8 +119,6 @@ def train():
 
     if cfg.parallel:
         build_strategy = fluid.BuildStrategy()
-        build_strategy.memory_optimize = False
-        build_strategy.enable_inplace = True
         exec_strategy = fluid.ExecutionStrategy()
         exec_strategy.num_iteration_per_drop_scope = 10
 

--- a/PaddleCV/ssd/train.py
+++ b/PaddleCV/ssd/train.py
@@ -209,7 +209,6 @@ def train(args,
     if parallel:
         loss.persistable = True
         build_strategy = fluid.BuildStrategy()
-        build_strategy.enable_inplace = True
         train_exe = fluid.ParallelExecutor(main_program=train_prog,
             use_cuda=use_gpu, loss_name=loss.name, build_strategy=build_strategy)
 

--- a/PaddleCV/yolov3/train.py
+++ b/PaddleCV/yolov3/train.py
@@ -111,7 +111,6 @@ def train():
         fluid.io.load_vars(exe, cfg.pretrain, predicate=if_exist)
 
     build_strategy = fluid.BuildStrategy()
-    build_strategy.memory_optimize = False  #gc and memory optimize may conflict
     syncbn = cfg.syncbn
     if (syncbn and devices_num <= 1) or num_trainers > 1:
         print("Disable syncbn in single device")

--- a/PaddleNLP/Research/ACL2019-KTNET/reading_comprehension/src/run_record.py
+++ b/PaddleNLP/Research/ACL2019-KTNET/reading_comprehension/src/run_record.py
@@ -398,8 +398,6 @@ def train(args):
                     ema = fluid.optimizer.ExponentialMovingAverage(args.ema_decay)
                     ema.update()
 
-                fluid.memory_optimize(train_program, skip_opt_set=[loss.name, num_seqs.name])
-
         if args.verbose:
             if args.in_tokens:
                 lower_mem, upper_mem, unit = fluid.contrib.memory_usage(
@@ -443,9 +441,6 @@ def train(args):
                 
                 if args.use_ema and 'ema' not in dir():
                     ema = fluid.optimizer.ExponentialMovingAverage(args.ema_decay)
-
-                fluid.memory_optimize(test_prog, skip_opt_set=[unique_ids.name,
-                    start_logits.name, end_logits.name, num_seqs.name])
 
         test_prog = test_prog.clone(for_test=True)
         # if args.random_seed is not None:

--- a/PaddleNLP/Research/ACL2019-KTNET/reading_comprehension/src/run_record_twomemory.py
+++ b/PaddleNLP/Research/ACL2019-KTNET/reading_comprehension/src/run_record_twomemory.py
@@ -426,8 +426,6 @@ def train(args):
                     ema = fluid.optimizer.ExponentialMovingAverage(args.ema_decay)
                     ema.update()
 
-                fluid.memory_optimize(train_program, skip_opt_set=[loss.name, num_seqs.name])
-
         if args.verbose:
             if args.in_tokens:
                 lower_mem, upper_mem, unit = fluid.contrib.memory_usage(
@@ -474,9 +472,6 @@ def train(args):
                 
                 if args.use_ema and 'ema' not in dir():
                     ema = fluid.optimizer.ExponentialMovingAverage(args.ema_decay)
-
-                fluid.memory_optimize(test_prog, skip_opt_set=[unique_ids.name,
-                    start_logits.name, end_logits.name, num_seqs.name])
 
         test_prog = test_prog.clone(for_test=True)
         # if args.random_seed is not None:

--- a/PaddleNLP/Research/ACL2019-KTNET/reading_comprehension/src/run_squad.py
+++ b/PaddleNLP/Research/ACL2019-KTNET/reading_comprehension/src/run_squad.py
@@ -398,8 +398,6 @@ def train(args):
                     ema = fluid.optimizer.ExponentialMovingAverage(args.ema_decay)
                     ema.update()
 
-                fluid.memory_optimize(train_program, skip_opt_set=[loss.name, num_seqs.name])
-
         if args.verbose:
             if args.in_tokens:
                 lower_mem, upper_mem, unit = fluid.contrib.memory_usage(
@@ -443,9 +441,6 @@ def train(args):
 
                 if args.use_ema and 'ema' not in dir():
                     ema = fluid.optimizer.ExponentialMovingAverage(args.ema_decay)
-
-                fluid.memory_optimize(test_prog, skip_opt_set=[unique_ids.name,
-                    start_logits.name, end_logits.name, num_seqs.name])
 
         test_prog = test_prog.clone(for_test=True)
         # if args.random_seed is not None:

--- a/PaddleNLP/Research/ACL2019-KTNET/reading_comprehension/src/run_squad_twomemory.py
+++ b/PaddleNLP/Research/ACL2019-KTNET/reading_comprehension/src/run_squad_twomemory.py
@@ -426,8 +426,6 @@ def train(args):
                     ema = fluid.optimizer.ExponentialMovingAverage(args.ema_decay)
                     ema.update()
 
-                fluid.memory_optimize(train_program, skip_opt_set=[loss.name, num_seqs.name])
-
         if args.verbose:
             if args.in_tokens:
                 lower_mem, upper_mem, unit = fluid.contrib.memory_usage(
@@ -474,9 +472,6 @@ def train(args):
                 
                 if args.use_ema and 'ema' not in dir():
                     ema = fluid.optimizer.ExponentialMovingAverage(args.ema_decay)
-
-                fluid.memory_optimize(test_prog, skip_opt_set=[unique_ids.name,
-                    start_logits.name, end_logits.name, num_seqs.name])
 
         test_prog = test_prog.clone(for_test=True)
         # if args.random_seed is not None:

--- a/PaddleNLP/dialogue_model_toolkit/auto_dialogue_evaluation/train.py
+++ b/PaddleNLP/dialogue_model_toolkit/auto_dialogue_evaluation/train.py
@@ -122,7 +122,6 @@ def do_train(args):
         print("finish init word embedding  ...")
 
     build_strategy = fluid.compiler.BuildStrategy()
-    build_strategy.enable_inplace = True
 
     compiled_train_prog = fluid.CompiledProgram(train_prog).with_data_parallel(
                 loss_name=loss.name, build_strategy=build_strategy)

--- a/PaddleNLP/dialogue_model_toolkit/dialogue_general_understanding/train.py
+++ b/PaddleNLP/dialogue_model_toolkit/dialogue_general_understanding/train.py
@@ -165,8 +165,6 @@ def do_train(args):
         save_load_io.init_from_pretrain_model(args, exe, train_prog)
 
     build_strategy = fluid.compiler.BuildStrategy()
-    build_strategy.enable_inplace = True
-
     compiled_train_prog = fluid.CompiledProgram(train_prog).with_data_parallel(
                 loss_name=loss.name, build_strategy=build_strategy)
     

--- a/PaddleNLP/language_model/train.py
+++ b/PaddleNLP/language_model/train.py
@@ -176,8 +176,6 @@ def main():
     exec_strategy.num_iteration_per_drop_scope = 100
 
     build_strategy = fluid.BuildStrategy()
-    build_strategy.enable_inplace = True
-    build_strategy.memory_optimize = False
     build_strategy.fuse_all_optimizer_ops = True
 
     if args.parallel:

--- a/PaddleNLP/lexical_analysis/train.py
+++ b/PaddleNLP/lexical_analysis/train.py
@@ -88,8 +88,6 @@ def do_train(args):
         exec_strategy = fluid.ExecutionStrategy()
         # exec_strategy.num_threads = dev_count * 6
         build_strategy = fluid.compiler.BuildStrategy()
-        # build_strategy.enable_inplace = True
-
         compiled_prog = fluid.compiler.CompiledProgram(train_program).with_data_parallel(
             loss_name=train_ret['avg_cost'].name,
             build_strategy=build_strategy,

--- a/PaddleNLP/neural_machine_translation/transformer/train.py
+++ b/PaddleNLP/neural_machine_translation/transformer/train.py
@@ -233,7 +233,6 @@ def do_train(args):
         init_from_pretrain_model(args, exe, train_prog)
 
     build_strategy = fluid.compiler.BuildStrategy()
-    build_strategy.enable_inplace = True
     exec_strategy = fluid.ExecutionStrategy()
     if num_trainers > 1:
         dist_utils.prepare_for_multi_process(exe, build_strategy, train_prog)

--- a/PaddleNLP/unarchived/neural_machine_translation/rnn_search/train.py
+++ b/PaddleNLP/unarchived/neural_machine_translation/rnn_search/train.py
@@ -126,8 +126,6 @@ def main():
     exec_strategy.num_iteration_per_drop_scope = 100
 
     build_strategy = fluid.BuildStrategy()
-    build_strategy.enable_inplace = True
-    build_strategy.memory_optimize = False
 #    build_strategy.fuse_all_optimizer_ops = True
 
     if args.parallel:

--- a/PaddleSlim/quant_low_level_api/quant.py
+++ b/PaddleSlim/quant_low_level_api/quant.py
@@ -255,7 +255,6 @@ def train(args):
         load_persistable_nodes(exe, checkpoint, main_graph)
 
     build_strategy = fluid.BuildStrategy()
-    build_strategy.memory_optimize = False
     build_strategy.enable_inplace = False
     binary = fluid.CompiledProgram(main_graph.graph).with_data_parallel(
         loss_name=train_cost.name, build_strategy=build_strategy)


### PR DESCRIPTION
As discussed with @lanxianghit , all models should run under at least PaddlePaddle 1.6+.

Remove `build_strategy.enable_inplace` and `build_strategy.memory_optimize` settings in models, since (1) inplace is enabled by default in 1.6; (2) memory optimize is not a good strategy and is disabled by default in 1.6.