### PR TITLE
[PaddleDetection] refine log in mask eval

### DIFF
--- a/PaddleCV/PaddleDetection/ppdet/utils/coco_eval.py
+++ b/PaddleCV/PaddleDetection/ppdet/utils/coco_eval.py
@@ -108,9 +108,10 @@ def mask_eval(results, anno_file, outfile, resolution, thresh_binarize=0.5):
     clsid2catid = {i + 1: v for i, v in enumerate(coco_gt.getCatIds())}
 
     segm_results = mask2out(results, clsid2catid, resolution, thresh_binarize)
-    assert len(
-        segm_results) > 0, "The number of valid mask detected is zero.\n \
-        Please use reasonable model and check input data."
+    if len(segm_results) == 0:
+        logger.warning("The number of valid mask detected is zero.\n \
+            Please use reasonable model and check input data.")
+        return
 
     with open(outfile, 'w') as f:
         json.dump(segm_results, f)


### PR DESCRIPTION
Replace assert by warning when mask_result is empty. As a result,  the training can continue regardless of eval result when training and evaluation at the same time.