### PR TITLE
Upgrade bert to 1.6 api

### DIFF
--- a/PaddleNLP/language_representations_kit/BERT/batching.py
+++ b/PaddleNLP/language_representations_kit/BERT/batching.py
@@ -155,7 +155,7 @@ def pad_batch_data(insts,
     inst_data = np.array([
         list(inst) + list([pad_idx] * (max_len - len(inst))) for inst in insts
     ])
-    return_list += [inst_data.astype("int64").reshape([-1, max_len, 1])]
+    return_list += [inst_data.astype("int64").reshape([-1, max_len])]
 
     # position data
     if return_pos:
@@ -164,7 +164,7 @@ def pad_batch_data(insts,
             for inst in insts
         ])
 
-        return_list += [inst_pos.astype("int64").reshape([-1, max_len, 1])]
+        return_list += [inst_pos.astype("int64").reshape([-1, max_len])]
 
     if return_input_mask:
         # This is used to avoid attention on paddings.

--- a/PaddleNLP/language_representations_kit/BERT/model/classifier.py
+++ b/PaddleNLP/language_representations_kit/BERT/model/classifier.py
@@ -25,9 +25,8 @@ from model.bert import BertModel
 def create_model(args, bert_config, num_labels, is_prediction=False):
     input_fields = {
         'names': ['src_ids', 'pos_ids', 'sent_ids', 'input_mask', 'labels'],
-        'shapes':
-        [[-1, args.max_seq_len, 1], [-1, args.max_seq_len, 1],
-         [-1, args.max_seq_len, 1], [-1, args.max_seq_len, 1], [-1, 1]],
+        'shapes': [[None, None], [None, None], [None, None],
+                   [-1, args.max_seq_len, 1], [-1, 1]],
         'dtypes': ['int64', 'int64', 'int64', 'float32', 'int64'],
         'lod_levels': [0, 0, 0, 0, 0],
     }
@@ -59,6 +58,7 @@ def create_model(args, bert_config, num_labels, is_prediction=False):
         dropout_implementation="upscale_in_train")
     logits = fluid.layers.fc(
         input=cls_feats,
+        num_flatten_dims=2,
         size=num_labels,
         param_attr=fluid.ParamAttr(
             name="cls_out_w",
@@ -73,6 +73,7 @@ def create_model(args, bert_config, num_labels, is_prediction=False):
         ]
         return pyreader, probs, feed_targets_name
 
+    logits = fluid.layers.reshape(logits, [-1, num_labels])
     ce_loss, probs = fluid.layers.softmax_with_cross_entropy(
         logits=logits, label=labels, return_softmax=True)
     loss = fluid.layers.mean(x=ce_loss)

--- a/PaddleNLP/language_representations_kit/BERT/model/classifier.py
+++ b/PaddleNLP/language_representations_kit/BERT/model/classifier.py
@@ -73,7 +73,7 @@ def create_model(args, bert_config, num_labels, is_prediction=False):
         ]
         return pyreader, probs, feed_targets_name
 
-    logits = fluid.layers.reshape(logits, [-1, num_labels])
+    logits = fluid.layers.reshape(logits, [-1, num_labels], inplace=True)
     ce_loss, probs = fluid.layers.softmax_with_cross_entropy(
         logits=logits, label=labels, return_softmax=True)
     loss = fluid.layers.mean(x=ce_loss)

--- a/PaddleNLP/language_representations_kit/BERT/run_classifier.py
+++ b/PaddleNLP/language_representations_kit/BERT/run_classifier.py
@@ -220,17 +220,6 @@ def main(args):
                     incr_ratio=args.incr_ratio,
                     decr_ratio=args.decr_ratio)
 
-        if args.verbose:
-            if args.in_tokens:
-                lower_mem, upper_mem, unit = fluid.contrib.memory_usage(
-                    program=train_program,
-                    batch_size=args.batch_size // args.max_seq_len)
-            else:
-                lower_mem, upper_mem, unit = fluid.contrib.memory_usage(
-                    program=train_program, batch_size=args.batch_size)
-            print("Theoretical memory usage in training: %.3f - %.3f %s" %
-                  (lower_mem, upper_mem, unit))
-
     if args.do_val:
         dev_prog = fluid.Program()
         with fluid.program_guard(dev_prog, startup_prog):

--- a/PaddleNLP/language_representations_kit/BERT/run_squad.py
+++ b/PaddleNLP/language_representations_kit/BERT/run_squad.py
@@ -104,8 +104,7 @@ def create_model(bert_config, is_training=False):
     if is_training:
         input_fields = {
             'names': ['src_ids', 'pos_ids', 'sent_ids', 'input_mask', 'start_positions', 'end_positions'],
-            'shapes': [[-1, args.max_seq_len, 1], [-1, args.max_seq_len, 1],
-                    [-1, args.max_seq_len, 1],
+            'shapes': [[None, None], [None, None], [None, None],
                     [-1, args.max_seq_len, 1], [-1, 1], [-1, 1]],
             'dtypes': [
                 'int64', 'int64', 'int64', 'float32', 'int64', 'int64'],
@@ -114,8 +113,7 @@ def create_model(bert_config, is_training=False):
     else:
         input_fields = {
             'names': ['src_ids', 'pos_ids', 'sent_ids', 'input_mask', 'unique_id'],
-            'shapes': [[-1, args.max_seq_len, 1], [-1, args.max_seq_len, 1],
-                    [-1, args.max_seq_len, 1],
+            'shapes': [[None, None], [None, None], [None, None],
                     [-1, args.max_seq_len, 1], [-1, 1]],
             'dtypes': [
                 'int64', 'int64', 'int64', 'float32', 'int64'],
@@ -295,17 +293,6 @@ def train(args):
                     decr_every_n_nan_or_inf=args.decr_every_n_nan_or_inf,
                     incr_ratio=args.incr_ratio,
                     decr_ratio=args.decr_ratio)
-
-        if args.verbose:
-            if args.in_tokens:
-                lower_mem, upper_mem, unit = fluid.contrib.memory_usage(
-                    program=train_program,
-                    batch_size=args.batch_size // args.max_seq_len)
-            else:
-                lower_mem, upper_mem, unit = fluid.contrib.memory_usage(
-                    program=train_program, batch_size=args.batch_size)
-            print("Theoretical memory usage in training:  %.3f - %.3f %s" %
-                  (lower_mem, upper_mem, unit))
 
     if args.do_predict:
         test_prog = fluid.Program()

--- a/PaddleNLP/language_representations_kit/BERT/train.py
+++ b/PaddleNLP/language_representations_kit/BERT/train.py
@@ -94,9 +94,8 @@ args = parser.parse_args()
 def create_model(bert_config):
     input_fields = {
         'names': ['src_ids', 'pos_ids', 'sent_ids', 'input_mask', 'mask_label', 'mask_pos', 'labels'],
-        'shapes': [[-1, args.max_seq_len, 1], [-1, args.max_seq_len, 1],
-                [-1, args.max_seq_len, 1],
-                [-1, args.max_seq_len, 1], [-1, 1], [-1, 1], [-1, 1]],
+        'shapes': [[None, None], [None, None], [None, None],
+                [None, None, 1], [None, 1], [None, 1], [None, 1]],
         'dtypes': ['int64', 'int64', 'int64', 'float32', 'int64', 'int64', 'int64'],
         'lod_levels': [0, 0, 0, 0, 0, 0, 0],
     }
@@ -259,16 +258,6 @@ def train(args):
         dev_count = int(os.environ.get('CPU_NUM', multiprocessing.cpu_count()))
 
     print("Device count %d" % dev_count)
-    if args.verbose:
-        if args.in_tokens:
-            lower_mem, upper_mem, unit = fluid.contrib.memory_usage(
-         program=train_program,
-         batch_size=args.batch_size // args.max_seq_len)
-        else:
-            lower_mem, upper_mem, unit = fluid.contrib.memory_usage(
-         program=train_program, batch_size=args.batch_size)
-        print("Theoretical memory usage in training: %.3f - %.3f %s" %
-              (lower_mem, upper_mem, unit))
 
     nccl2_num_trainers = 1
     nccl2_trainer_id = 0


### PR DESCRIPTION
1. Use `fluid.data()` and `fluid.embedding()`
2. Remove `fluid.contrib.memory_usage()` because there are two unknown dimensions now and it cannot work any more.