### PR TITLE
remove actual_shape in resize_nearest and use_progam_cache in yolov3/infer.py

### DIFF
--- a/PaddleCV/PaddleDetection/ppdet/modeling/anchor_heads/yolo_head.py
+++ b/PaddleCV/PaddleDetection/ppdet/modeling/anchor_heads/yolo_head.py
@@ -148,18 +148,8 @@ class YOLOv3Head(object):
         return route, tip
 
     def _upsample(self, input, scale=2, name=None):
-        # get dynamic upsample output shape
-        shape_nchw = fluid.layers.shape(input)
-        shape_hw = fluid.layers.slice(
-            shape_nchw, axes=[0], starts=[2], ends=[4])
-        shape_hw.stop_gradient = True
-        in_shape = fluid.layers.cast(shape_hw, dtype='int32')
-        out_shape = in_shape * scale
-        out_shape.stop_gradient = True
-
-        # reisze by actual_shape
         out = fluid.layers.resize_nearest(
-            input=input, scale=scale, actual_shape=out_shape, name=name)
+            input=input, scale=float(scale), name=name)
         return out
 
     def _parse_anchors(self, anchors):

--- a/PaddleCV/PaddleDetection/ppdet/modeling/backbones/fpn.py
+++ b/PaddleCV/PaddleDetection/ppdet/modeling/backbones/fpn.py
@@ -87,13 +87,8 @@ class FPN(object):
                     learning_rate=2.,
                     regularizer=L2Decay(0.)),
                 name=lateral_name)
-        shape = fluid.layers.shape(upper_output)
-        shape_hw = fluid.layers.slice(shape, axes=[0], starts=[2], ends=[4])
-        out_shape_ = shape_hw * 2
-        out_shape = fluid.layers.cast(out_shape_, dtype='int32')
-        out_shape.stop_gradient = True
         topdown = fluid.layers.resize_nearest(
-            upper_output, scale=2., actual_shape=out_shape, name=topdown_name)
+            upper_output, scale=2., name=topdown_name)
 
         return lateral + topdown
 

--- a/PaddleCV/yolov3/infer.py
+++ b/PaddleCV/yolov3/infer.py
@@ -70,7 +70,8 @@ def infer():
         im_shape = data[0][2]
         outputs = exe.run(fetch_list=[v.name for v in fetch_list],
                           feed=feeder.feed(data),
-                          return_numpy=False)
+                          return_numpy=False,
+                          use_program_cache=True)
         bboxes = np.array(outputs[0])
         if bboxes.shape[1] != 6:
             print("No object found in {}".format(image_name))

--- a/PaddleCV/yolov3/models/yolov3.py
+++ b/PaddleCV/yolov3/models/yolov3.py
@@ -68,17 +68,8 @@ def yolo_detection_block(input, channel, is_test=True, name=None):
 
 
 def upsample(input, scale=2, name=None):
-    # get dynamic upsample output shape
-    shape_nchw = fluid.layers.shape(input)
-    shape_hw = fluid.layers.slice(shape_nchw, axes=[0], starts=[2], ends=[4])
-    shape_hw.stop_gradient = True
-    in_shape = fluid.layers.cast(shape_hw, dtype='int32')
-    out_shape = in_shape * scale
-    out_shape.stop_gradient = True
-
-    # reisze by actual_shape
     out = fluid.layers.resize_nearest(
-        input=input, scale=scale, actual_shape=out_shape, name=name)
+        input=input, scale=float(scale), name=name)
     return out
 
 


### PR DESCRIPTION
1. `scale` parameter for `resize_nearest` change to scale input dynamically since Paddle 1.5, change to use scale to upsample feature maps in yolov3 and fpn
2. set `use_program_cache=True` in yolov3/infer.py, see https://github.com/PaddlePaddle/models/issues/3571