### PR TITLE
Polish usage of deprecated or private API in dygraph

### DIFF
--- a/PaddleNLP/Research/Dialogue-PLATO/plato/modules/parallel.py
+++ b/PaddleNLP/Research/Dialogue-PLATO/plato/modules/parallel.py
@@ -226,12 +226,8 @@ class DataParallel(layers.Layer):
         grad_vars = []
         for param in self._layers.parameters():
             # NOTE(zcd): The grad_ivar maybe no generated.
-            if param.trainable and param._ivar._grad_ivar():
-                g_var = framework.Variable(
-                    block=self._helper.main_program.current_block(),
-                    name=param._ivar._grad_name(),
-                    stop_gradient=True,
-                    ivar=param._ivar._grad_ivar())
+            if param.trainable and param._grad_ivar():
+                g_var = param._grad_ivar()
                 grad_vars.append(g_var)
                 assert g_var not in grad_var_set
                 grad_var_set.add(g_var)

--- a/PaddleSpeech/DeepVoice3/deepvoice3_paddle/modules.py
+++ b/PaddleSpeech/DeepVoice3/deepvoice3_paddle/modules.py
@@ -367,7 +367,7 @@ class PositionEmbedding(dg.Layer):
 
     def set_weight(self, array):
         assert self.embed._w.shape == list(array.shape), "shape does not match"
-        self.embed._w._ivar.value().get_tensor().set(
+        self.embed._w.value().get_tensor().set(
             array, fluid.framework._current_expected_place())
 
     def forward(self, indices, speaker_position_rate=None):

--- a/dygraph/ocr_recognition/train.py
+++ b/dygraph/ocr_recognition/train.py
@@ -486,8 +486,7 @@ def train(args):
                 label_in = to_variable(data_dict["label_in"])
                 label_out = to_variable(data_dict["label_out"])
 
-                label_out._stop_gradient = True
-                label_out.trainable = False
+                label_out.stop_gradient = True
 
                 img = to_variable(data_dict["pixel"])
 
@@ -528,8 +527,7 @@ def train(args):
                 label_in = to_variable(data_dict["label_in"])
                 label_out = to_variable(data_dict["label_out"])
 
-                label_out._stop_gradient = True
-                label_out.trainable = False
+                label_out.stop_gradient = True
 
                 img = to_variable(data_dict["pixel"])
 
@@ -548,8 +546,6 @@ def train(args):
                 avg_loss.backward()
                 optimizer.minimize(avg_loss, grad_clip=grad_clip)
                 ocr_attention.clear_gradients()
-
-                framework._dygraph_tracer()._clear_ops()
 
                 if batch_id > 0 and batch_id % 1000 == 0:
                     print("epoch: {}, batch_id: {}, loss {}".format(epoch, batch_id, total_loss / args.batch_size / 1000))

--- a/dygraph/resnet/train.py
+++ b/dygraph/resnet/train.py
@@ -247,7 +247,7 @@ def eval(model, data):
 
         img = to_variable(dy_x_data)
         label = to_variable(y_data)
-        label._stop_gradient = True
+        label.stop_gradient = True
 
         out = model(img)
         #loss = fluid.layers.cross_entropy(input=out, label=label)
@@ -335,7 +335,7 @@ def train_resnet():
 
                 img = to_variable(dy_x_data)
                 label = to_variable(y_data)
-                label._stop_gradient = True
+                label.stop_gradient = True
 
                 out = resnet(img)
                 loss = fluid.layers.cross_entropy(input=out, label=label)

--- a/dygraph/se_resnext/train.py
+++ b/dygraph/se_resnext/train.py
@@ -336,7 +336,7 @@ def eval(model, data):
 
         img = to_variable(dy_x_data)
         label = to_variable(y_data)
-        label._stop_gradient = True
+        label.stop_gradient = True
         out = model(img)
 
         softmax_out = fluid.layers.softmax(out, use_cudnn=False)


### PR DESCRIPTION
As the title, this PR Polishes the usage of deprecated or private API in dygraph, i.e., APIs start with `_`.

- `_ivar` is removed since [PR21359](https://github.com/PaddlePaddle/Paddle/pull/21359), we split VarBase (which is used in dygraph mode) from Variable (which is used in static mode). `to_variable` and `layers.xx` will return an `VarBase` object, Variable does not hold `_ivar` any more.
- `_stop_gradient` is a private API, use `stop_gradient` instead.