### PR TITLE
fix point_rcnn elementwise_mul compatible

### DIFF
--- a/PaddleCV/Paddle3D/PointNet++/README.md
+++ b/PaddleCV/Paddle3D/PointNet++/README.md
@@ -212,8 +212,8 @@ sh scripts/eval_cls.sh
 
 | model | Top-1 | download |
 | :----- | :---: | :---: |
-| SSG(Single-Scale Group) | 87.4 | [model](https://paddlemodels.bj.bcebos.com/Paddle3D/pointnet2_ssg_cls.tar) |
-| MSG(Multi-Scale Group)  | 89.1 | [model](https://paddlemodels.bj.bcebos.com/Paddle3D/pointnet2_msg_cls.tar) |
+| SSG(Single-Scale Group) | 89.3 | [model](https://paddlemodels.bj.bcebos.com/Paddle3D/pointnet2_ssg_cls.tar) |
+| MSG(Multi-Scale Group)  | 90.0 | [model](https://paddlemodels.bj.bcebos.com/Paddle3D/pointnet2_msg_cls.tar) |
 
 **语义分割模型:**
 

--- a/PaddleCV/Paddle3D/PointNet++/README_en.md
+++ b/PaddleCV/Paddle3D/PointNet++/README_en.md
@@ -212,8 +212,8 @@ Classification model evaluation result is shown as below:
 
 | model | Top-1 | download |
 | :----- | :---: | :---: |
-| SSG(Single-Scale Group) | 87.6 | [model]() |
-| MSG(Multi-Scale Group)  | 89.2 | [model]() |
+| SSG(Single-Scale Group) | 89.3 | [model]() |
+| MSG(Multi-Scale Group)  | 90.0 | [model]() |
 
 **Semantic Segmentation Model:**
 

--- a/PaddleCV/Paddle3D/PointRCNN/README.md
+++ b/PaddleCV/Paddle3D/PointRCNN/README.md
@@ -81,7 +81,7 @@ pip install -r requirement.txt
     sh make.sh
     ```
 
-    成功编译后，`ext_op/src` 目录下将会生成 `pointnet2_lib.so` 
+    成功编译后，`ext_op/src` 目录下将会生成 `pointnet_lib.so` 
 
     执行下列操作，确保自定义算子编译正确：
 

--- a/PaddleCV/Paddle3D/PointRCNN/models/loss_utils.py
+++ b/PaddleCV/Paddle3D/PointRCNN/models/loss_utils.py
@@ -190,7 +190,9 @@ def get_reg_loss(pred_reg, reg_label, fg_mask, point_num, loc_scope,
     size_res_norm = pred_reg[:, size_res_l:size_res_r]
     size_res_norm = fluid.layers.reshape(size_res_norm, shape=[-1, 1], inplace=True)
     size_loss = fluid.layers.smooth_l1(size_res_norm, size_res_norm_label)
-    size_loss = fluid.layers.reduce_mean(fluid.layers.reshape(size_loss, [-1, 3]) * fg_mask) * fg_scale
+    size_loss = fluid.layers.reshape(size_loss, shape=[-1, 3])
+    size_loss = fluid.layers.elementwise_mul(size_loss, fg_mask, axis=0)
+    size_loss = fluid.layers.reduce_mean(size_loss) * fg_scale
 
     # Total regression loss
     reg_loss_dict['loss_loc'] = loc_loss

--- a/PaddleCV/Paddle3D/PointRCNN/models/rcnn.py
+++ b/PaddleCV/Paddle3D/PointRCNN/models/rcnn.py
@@ -281,8 +281,9 @@ class RCNN(object):
         all_anchor_size = roi_size
         anchor_size = all_anchor_size[fg_mask] if self.cfg.RCNN.SIZE_RES_ON_ROI else self.cfg.CLS_MEAN_SIZE[0]
 
+        masked_reg_out = fluid.layers.elementwise_mul(reg_out, fg_mask, axis=0)
         loc_loss, angle_loss, size_loss, loss_dict = get_reg_loss(
-            fluid.layers.elementwise_mul(reg_out, fg_mask, axis=0),
+            masked_reg_out,
             gt_boxes3d_ct,
             fg_mask,
             point_num=float(self.batch_size*64),

--- a/PaddleCV/Paddle3D/PointRCNN/models/rcnn.py
+++ b/PaddleCV/Paddle3D/PointRCNN/models/rcnn.py
@@ -282,7 +282,7 @@ class RCNN(object):
         anchor_size = all_anchor_size[fg_mask] if self.cfg.RCNN.SIZE_RES_ON_ROI else self.cfg.CLS_MEAN_SIZE[0]
 
         loc_loss, angle_loss, size_loss, loss_dict = get_reg_loss(
-            reg_out * fg_mask,
+            fluid.layers.elementwise_mul(reg_out, fg_mask, axis=0),
             gt_boxes3d_ct,
             fg_mask,
             point_num=float(self.batch_size*64),

--- a/PaddleCV/Paddle3D/PointRCNN/models/rpn.py
+++ b/PaddleCV/Paddle3D/PointRCNN/models/rpn.py
@@ -150,8 +150,9 @@ class RPN(object):
         reg_label = fluid.layers.reshape(rpn_reg_label, [-1, rpn_reg_label.shape[-1]])
         fg_mask = fluid.layers.cast(cls_label_flat > 0, dtype=rpn_reg.dtype)
         fg_mask.stop_gradient = True
+        masked_rpn_reg = fluid.layers.elementwise_mul(rpn_reg, fg_mask, axis=0)
         loc_loss, angle_loss, size_loss, loss_dict = get_reg_loss(
-            fluid.layers.elementwise_mul(rpn_reg, fg_mask, axis=0),
+            masked_rpn_reg,
             reg_label,
             fg_mask,
             float(self.batch_size * self.cfg.RPN.NUM_POINTS),

--- a/PaddleCV/Paddle3D/PointRCNN/models/rpn.py
+++ b/PaddleCV/Paddle3D/PointRCNN/models/rpn.py
@@ -151,17 +151,20 @@ class RPN(object):
         fg_mask = fluid.layers.cast(cls_label_flat > 0, dtype=rpn_reg.dtype)
         fg_mask.stop_gradient = True
         loc_loss, angle_loss, size_loss, loss_dict = get_reg_loss(
-                                        rpn_reg * fg_mask, reg_label, fg_mask,
-                                        float(self.batch_size * self.cfg.RPN.NUM_POINTS),
-                                        loc_scope=self.cfg.RPN.LOC_SCOPE,
-                                        loc_bin_size=self.cfg.RPN.LOC_BIN_SIZE,
-                                        num_head_bin=self.cfg.RPN.NUM_HEAD_BIN,
-                                        anchor_size=self.cfg.CLS_MEAN_SIZE[0],
-                                        get_xz_fine=self.cfg.RPN.LOC_XZ_FINE,
-                                        get_y_by_bin=False,
-                                        get_ry_fine=False)
+            fluid.layers.elementwise_mul(rpn_reg, fg_mask, axis=0),
+            reg_label,
+            fg_mask,
+            float(self.batch_size * self.cfg.RPN.NUM_POINTS),
+            loc_scope=self.cfg.RPN.LOC_SCOPE,
+            loc_bin_size=self.cfg.RPN.LOC_BIN_SIZE,
+            num_head_bin=self.cfg.RPN.NUM_HEAD_BIN,
+            anchor_size=self.cfg.CLS_MEAN_SIZE[0],
+            get_xz_fine=self.cfg.RPN.LOC_XZ_FINE,
+            get_y_by_bin=False,
+            get_ry_fine=False)
         rpn_loss_reg = loc_loss + angle_loss + size_loss * 3
 
-        self.rpn_loss = rpn_loss_cls * self.cfg.RPN.LOSS_WEIGHT[0] + rpn_loss_reg * self.cfg.RPN.LOSS_WEIGHT[1]
+        self.rpn_loss = rpn_loss_cls * self.cfg.RPN.LOSS_WEIGHT[0] \
+                            + rpn_loss_reg * self.cfg.RPN.LOSS_WEIGHT[1]
         return self.rpn_loss, rpn_loss_cls, rpn_loss_reg
         


### PR DESCRIPTION
**fix point_rcnn elementwise_compatable**
- elementwise broadcast changed since https://github.com/PaddlePaddle/Paddle/pull/21517 , [2, 3] * [2] is not supported now, compatible with this change
- fix typo in PointRCNN README
- update model weights and Top-1 using best model trained by QA