### PR TITLE
refix point_rcnn elementwise compatible.

### DIFF
--- a/PaddleCV/Paddle3D/PointRCNN/models/loss_utils.py
+++ b/PaddleCV/Paddle3D/PointRCNN/models/loss_utils.py
@@ -191,8 +191,7 @@ def get_reg_loss(pred_reg, reg_label, fg_mask, point_num, loc_scope,
     size_res_norm = fluid.layers.reshape(size_res_norm, shape=[-1, 1], inplace=True)
     size_loss = fluid.layers.smooth_l1(size_res_norm, size_res_norm_label)
     size_loss = fluid.layers.reshape(size_loss, shape=[-1, 3])
-    size_loss = fluid.layers.elementwise_mul(size_loss, fg_mask, axis=0)
-    size_loss = fluid.layers.reduce_mean(size_loss) * fg_scale
+    size_loss = fluid.layers.reduce_mean(size_loss * fg_mask) * fg_scale
 
     # Total regression loss
     reg_loss_dict['loss_loc'] = loc_loss

--- a/PaddleCV/Paddle3D/PointRCNN/models/rcnn.py
+++ b/PaddleCV/Paddle3D/PointRCNN/models/rcnn.py
@@ -276,14 +276,14 @@ class RCNN(object):
         # RCNN regression loss
         reg_out = self.reg_out
         fg_mask = fluid.layers.cast(reg_valid_mask > 0, dtype=reg_out.dtype)
+        fg_mask = fluid.layers.unsqueeze(fg_mask, axes=[1])
         fg_mask.stop_gradient = True
         gt_boxes3d_ct = fluid.layers.reshape(gt_boxes3d_ct, [-1,7])
         all_anchor_size = roi_size
         anchor_size = all_anchor_size[fg_mask] if self.cfg.RCNN.SIZE_RES_ON_ROI else self.cfg.CLS_MEAN_SIZE[0]
 
-        masked_reg_out = fluid.layers.elementwise_mul(reg_out, fg_mask, axis=0)
         loc_loss, angle_loss, size_loss, loss_dict = get_reg_loss(
-            masked_reg_out,
+            reg_out * fg_mask, 
             gt_boxes3d_ct,
             fg_mask,
             point_num=float(self.batch_size*64),

--- a/PaddleCV/Paddle3D/PointRCNN/models/rpn.py
+++ b/PaddleCV/Paddle3D/PointRCNN/models/rpn.py
@@ -149,10 +149,10 @@ class RPN(object):
         rpn_reg = fluid.layers.reshape(rpn_reg, [-1, rpn_reg.shape[-1]])
         reg_label = fluid.layers.reshape(rpn_reg_label, [-1, rpn_reg_label.shape[-1]])
         fg_mask = fluid.layers.cast(cls_label_flat > 0, dtype=rpn_reg.dtype)
+        fg_mask = fluid.layers.unsqueeze(fg_mask, axes=[1])
         fg_mask.stop_gradient = True
-        masked_rpn_reg = fluid.layers.elementwise_mul(rpn_reg, fg_mask, axis=0)
         loc_loss, angle_loss, size_loss, loss_dict = get_reg_loss(
-            masked_rpn_reg,
+            rpn_reg * fg_mask,
             reg_label,
             fg_mask,
             float(self.batch_size * self.cfg.RPN.NUM_POINTS),


### PR DESCRIPTION
**refix point_rcnn elementwise compatible**
For [2, 1] * [2] -> [2, 2] now, unsqueeze `fg_mask` in axis 1 to shape [-1, 1] to compatible to following elementwise operation