### PR TITLE
Fix distillation nan issue

### DIFF
--- a/PaddleSlim/configs/mobilenetv1_resnet50_distillation.yaml
+++ b/PaddleSlim/configs/mobilenetv1_resnet50_distillation.yaml
@@ -1,10 +1,5 @@
 version: 1.0
 distillers:
-    fsp_distiller:
-        class: 'FSPDistiller'
-        teacher_pairs: [['res2a_branch2a.conv2d.output.1.tmp_0', 'res3a_branch2a.conv2d.output.1.tmp_0']]
-        student_pairs: [['depthwise_conv2d_1.tmp_0', 'conv2d_3.tmp_0']]
-        distillation_loss_weight: 1
     l2_distiller:
         class: 'L2Distiller'
         teacher_feature_map: 'res_fc.tmp_0'
@@ -13,7 +8,7 @@ distillers:
 strategies:
     distillation_strategy:
         class: 'DistillationStrategy'
-        distillers: ['fsp_distiller', 'l2_distiller']
+        distillers: ['l2_distiller']
         start_epoch: 0
         end_epoch: 130
 compressor:


### PR DESCRIPTION
Temporary disable fsp_distiller in PaddleSlim. Need to find out why fsp_distiller is prone to  `NAN` issues