### PR TITLE
[PaddleRec] fix Nan loss  and hash problem in dnn model

### DIFF
--- a/PaddleRec/ctr/dnn/network_conf.py
+++ b/PaddleRec/ctr/dnn/network_conf.py
@@ -201,13 +201,13 @@ def ctr_dnn_model(embedding_size, sparse_feature_dim, use_py_reader=True):
                               initializer=fluid.initializer.Normal(
                                   scale=1 / math.sqrt(fc2.shape[1]))))
     predict = fluid.layers.fc(input=fc3,
-                              size=2,
-                              act='softmax',
+                              size=1,
+                              act='sigmoid',
                               param_attr=fluid.ParamAttr(
                                   initializer=fluid.initializer.Normal(
                                       scale=1 / math.sqrt(fc3.shape[1]))))
 
-    cost = fluid.layers.cross_entropy(input=predict, label=words[-1])
+    cost = fluid.layers.log_loss(input=predict, label=fluid.layers.cast(words[-1], dtype="float32"))
     avg_cost = fluid.layers.reduce_sum(cost)
     accuracy = fluid.layers.accuracy(input=predict, label=words[-1])
     auc_var, batch_auc_var, auc_states = \

--- a/PaddleRec/ctr/dnn/reader.py
+++ b/PaddleRec/ctr/dnn/reader.py
@@ -1,3 +1,6 @@
+import mmh3
+
+
 class Dataset:
     def __init__(self):
         pass
@@ -43,7 +46,8 @@ class CriteoDataset(Dataset):
                                                      self.cont_diff_[idx - 1])
                         for idx in self.categorical_range_:
                             sparse_feature.append([
-                                hash(str(idx) + features[idx]) % self.hash_dim_
+                                mmh3.hash(str(idx) + features[idx]) %
+                                self.hash_dim_
                             ])
 
                         label = [int(features[0])]

--- a/PaddleRec/ctr/dnn/requirements.txt
+++ b/PaddleRec/ctr/dnn/requirements.txt
@@ -1,1 +1,2 @@
 click
+mmh3


### PR DESCRIPTION
bug fix:
1.  change cross_entropy to log_loss to avoid Nan loss in training.
2. change hash to mmh3.hash to return same hash value in python2 and python3.