### PR TITLE
[face detection] fix big input size of shrink

### DIFF
--- a/PaddleCV/face_detection/widerface_eval.py
+++ b/PaddleCV/face_detection/widerface_eval.py
@@ -22,10 +22,12 @@ import argparse
 import functools
 from PIL import Image
 
+
 def set_paddle_flags(**kwargs):
     for key, value in kwargs.items():
         if os.environ.get(key, None) is None:
             os.environ[key] = str(value)
+
 
 # NOTE(paddle-dev): All of these flags should be
 # set before `import paddle`. Otherwise, it would
@@ -33,7 +35,6 @@ def set_paddle_flags(**kwargs):
 set_paddle_flags(
     FLAGS_eager_delete_tensor_gb=0,  # enable GC to save memory
 )
-
 
 import paddle.fluid as fluid
 import reader
@@ -315,6 +316,8 @@ def get_shrink(height, width):
         max_shrink = max_shrink - 0.4
     elif max_shrink >= 5:
         max_shrink = max_shrink - 0.5
+    elif max_shrink <= 0.1:
+        max_shrink = 0.1
 
     shrink = max_shrink if max_shrink < 1 else 1
     return shrink, max_shrink


### PR DESCRIPTION
fix #4082 
Tested with the coefficients of 0.1, 0.2, 0.3, the effect is best when the shrink is 0.1