### PR TITLE
support out json in multi-card eval and add exclude fc params in finetune

### DIFF
--- a/PaddleCV/image_classification/infer.py
+++ b/PaddleCV/image_classification/infer.py
@@ -101,8 +101,8 @@ def infer(args):
     place = fluid.CUDAPlace(0) if args.use_gpu else fluid.CPUPlace()
     exe = fluid.Executor(place)
     exe.run(fluid.default_startup_program())
-
-    places = fluid.framework.cuda_places()
+    if args.use_gpu:
+        places = fluid.framework.cuda_places()
     compiled_program = fluid.compiler.CompiledProgram(
         test_program).with_data_parallel(places=places)
 

--- a/PaddleCV/image_classification/infer.py
+++ b/PaddleCV/image_classification/infer.py
@@ -97,10 +97,11 @@ def infer(args):
     test_program = fluid.default_main_program().clone(for_test=True)
 
     fetch_list = [out.name]
-
-    place = fluid.CUDAPlace(0) if args.use_gpu else fluid.CPUPlace()
+    gpu_id = int(os.environ.get('FLAGS_selected_gpus', 0))
+    place = fluid.CUDAPlace(gpu_id) if args.use_gpu else fluid.CPUPlace()
     exe = fluid.Executor(place)
     exe.run(fluid.default_startup_program())
+    places = place
     if args.use_gpu:
         places = fluid.framework.cuda_places()
     compiled_program = fluid.compiler.CompiledProgram(
@@ -140,7 +141,7 @@ def infer(args):
     info = {}
     parallel_data = []
     parallel_id = []
-    place_num = paddle.fluid.core.get_cuda_device_count()
+    place_num = paddle.fluid.core.get_cuda_device_count() if args.use_gpu else 1
 
     for batch_id, data in enumerate(test_reader()):
         image_data = [[items[0]] for items in data]

--- a/PaddleCV/image_classification/utils/utility.py
+++ b/PaddleCV/image_classification/utils/utility.py
@@ -92,6 +92,7 @@ def parse_args():
     add_arg('model_save_dir',           str,    "./output",        "The directory path to save model.")
     add_arg('data_dir',                 str,    "./data/ILSVRC2012/",   "The ImageNet dataset root directory.")
     add_arg('pretrained_model',         str,    None,                   "Whether to load pretrained model.")
+    add_arg('finetune_exclude_pretrained_params', str, None,            "Ignore params when doing finetune")
     add_arg('checkpoint',               str,    None,                   "Whether to resume checkpoint.")
     add_arg('print_step',               int,    10,                     "The steps interval to print logs")
     add_arg('save_step',                int,    1,                      "The steps interval to save checkpoints")
@@ -293,9 +294,9 @@ def init_model(exe, args, program):
         print("Finish initing model from %s" % (args.checkpoint))
 
     if args.pretrained_model:
+        """
         # yapf: disable
-
-        #XXX: should rename all models' final fc layers name as final_fc_weights and final_fc_offset!
+        # This is a dict of fc layers in all the classification models.
         final_fc_name = [
                          "fc8_weights","fc8_offset", #alexnet
                          "fc_weights","fc_offset", #darknet, densenet, dpn, hrnet, mobilenet_v3, res2net, res2net_vd, resnext, resnext_vd, xception
@@ -312,6 +313,13 @@ def init_model(exe, args, program):
                          "fc_bias" #"fc_weights", xception_deeplab
                          ]
         # yapf: enable
+        """
+        final_fc_name = []
+        if args.finetune_exclude_pretrained_params:
+            final_fc_name = [
+                str(s)
+                for s in args.finetune_exclude_pretrained_params.split(",")
+            ]
 
         def is_parameter(var):
             fc_exclude_flag = False
@@ -324,8 +332,8 @@ def init_model(exe, args, program):
                 Parameter) and not fc_exclude_flag and os.path.exists(
                     os.path.join(args.pretrained_model, var.name))
 
-        print("Load pretrain weights from {}, exclude fc layer.".format(
-            args.pretrained_model))
+        print("Load pretrain weights from {}, exclude params {}.".format(
+            args.pretrained_model, final_fc_name))
         vars = filter(is_parameter, program.list_vars())
         fluid.io.load_vars(
             exe, args.pretrained_model, vars=vars, main_program=program)
@@ -474,7 +482,6 @@ def print_info(info_mode,
             time_info
         ) > 10, "0~9th batch statistics will drop when doing benchmark or ce, because it might be mixed with startup time, so please make sure training at least 10 batches."
         print_ce(device_num, metrics, time_info)
-        #raise Warning("CE code is not ready")
     else:
         raise Exception("Illegal info_mode")
 


### PR DESCRIPTION
- support output the JSON file while doing multi-card eval in the image classification
**Note:**  To solve the problem about the framework cannot pass string variable into the network and there is a strong demand to get  it, we create a reader which always generate a batch of image_id(string) and image_data(data and label) and only feed the image_data when the executor runs, the python interface: **feeder.feed_parallel** is workable to implement it, note that **feeder.decorate_reader** ask the reader should be consistent with the feeder
After doing this, the exe.run will return the observation value in the fetch list as a shape of [the single card batch size, the size of fetch_list, image_shape]
The JSON file will be saved at the ./ in default
- add args:exclude to load pre-trained model correctly while doing finetune
- refine some warning