### PR TITLE
fix ocr_recognition model for dygraph incompatible upgrade

### DIFF
--- a/dygraph/ocr_recognition/train.py
+++ b/dygraph/ocr_recognition/train.py
@@ -20,7 +20,7 @@ import paddle.fluid.profiler as profiler
 import paddle.fluid as fluid
 import paddle.fluid.layers as layers
 import data_reader
-from paddle.fluid.dygraph.nn import Conv2D, Pool2D, FC, BatchNorm, Embedding, GRUUnit
+from paddle.fluid.dygraph.nn import Conv2D, Pool2D, Linear, BatchNorm, Embedding, GRUUnit
 from paddle.fluid.dygraph.base import to_variable
 import argparse
 import functools
@@ -84,7 +84,7 @@ class Config(object):
 
 class ConvBNPool(fluid.dygraph.Layer):
     def __init__(self,
-                 name_scope,
+                 num_channels,
                  group,
                  out_ch,
                  channels,
@@ -92,7 +92,7 @@ class ConvBNPool(fluid.dygraph.Layer):
                  is_test=False,
                  pool=True,
                  use_cudnn=True):
-        super(ConvBNPool, self).__init__(name_scope)
+        super(ConvBNPool, self).__init__()
         self.group = group
         self.pool = pool
 
@@ -106,7 +106,7 @@ class ConvBNPool(fluid.dygraph.Layer):
             initializer=fluid.initializer.Normal(0.0, conv_std_1))
 
         self.conv_0_layer = Conv2D(
-            self.full_name(),
+            num_channels,
             out_ch[0],
             3,
             padding=1,
@@ -115,9 +115,9 @@ class ConvBNPool(fluid.dygraph.Layer):
             act=None,
             use_cudnn=use_cudnn)
         self.bn_0_layer = BatchNorm(
-            self.full_name(), out_ch[0], act=act, is_test=is_test)
+            out_ch[0], act=act, is_test=is_test)
         self.conv_1_layer = Conv2D(
-            self.full_name(),
+            out_ch[0],
             num_filters=out_ch[1],
             filter_size=3,
             padding=1,
@@ -126,12 +126,10 @@ class ConvBNPool(fluid.dygraph.Layer):
             act=None,
             use_cudnn=use_cudnn)
         self.bn_1_layer = BatchNorm(
-            self.full_name(), out_ch[1], act=act, is_test=is_test)
+            out_ch[1], act=act, is_test=is_test)
 
-        print( "pool", self.pool)
         if self.pool:
             self.pool_layer = Pool2D(
-                self.full_name(),
                 pool_size=2,
                 pool_type='max',
                 pool_stride=2,
@@ -151,26 +149,22 @@ class ConvBNPool(fluid.dygraph.Layer):
 
 
 class OCRConv(fluid.dygraph.Layer):
-    def __init__(self, name_scope, is_test=False, use_cudnn=True):
-        super(OCRConv, self).__init__(name_scope)
+    def __init__(self,  is_test=False, use_cudnn=True):
+        super(OCRConv, self).__init__()
         self.conv_bn_pool_1 = ConvBNPool(
-            self.full_name(),
-            2, [16, 16], [1, 16],
+            1, 2, [16, 16], [1, 16],
             is_test=is_test,
             use_cudnn=use_cudnn)
         self.conv_bn_pool_2 = ConvBNPool(
-            self.full_name(),
-            2, [32, 32], [16, 32],
+            16, 2, [32, 32], [16, 32],
             is_test=is_test,
             use_cudnn=use_cudnn)
         self.conv_bn_pool_3 = ConvBNPool(
-            self.full_name(),
-            2, [64, 64], [32, 64],
+            32, 2, [64, 64], [32, 64],
             is_test=is_test,
             use_cudnn=use_cudnn)
         self.conv_bn_pool_4 = ConvBNPool(
-            self.full_name(),
-            2, [128, 128], [64, 128],
+            64, 2, [128, 128], [64, 128],
             is_test=is_test,
             pool=False,
             use_cudnn=use_cudnn)
@@ -187,7 +181,6 @@ class OCRConv(fluid.dygraph.Layer):
 
 class DynamicGRU(fluid.dygraph.Layer):
     def __init__(self,
-                 scope_name,
                  size,
                  param_attr=None,
                  bias_attr=None,
@@ -197,10 +190,9 @@ class DynamicGRU(fluid.dygraph.Layer):
                  h_0=None,
                  origin_mode=False,
                  init_size = None):
-        super(DynamicGRU, self).__init__(scope_name)
+        super(DynamicGRU, self).__init__()
 
         self.gru_unit = GRUUnit(
-            self.full_name(),
             size * 3,
             param_attr=param_attr,
             bias_attr=bias_attr,
@@ -239,11 +231,10 @@ class DynamicGRU(fluid.dygraph.Layer):
 
 class EncoderNet(fluid.dygraph.Layer):
     def __init__(self,
-                 scope_name,
                  rnn_hidden_size=200,
                  is_test=False,
                  use_cudnn=True):
-        super(EncoderNet, self).__init__(scope_name)
+        super(EncoderNet, self).__init__()
         self.rnn_hidden_size = rnn_hidden_size
         para_attr = fluid.ParamAttr(initializer=fluid.initializer.Normal(0.0,
                                                                          0.02))
@@ -259,27 +250,24 @@ class EncoderNet(fluid.dygraph.Layer):
                 dtype='float32',
                 value=0)
         self.ocr_convs = OCRConv(
-            self.full_name(), is_test=is_test, use_cudnn=use_cudnn)
+            is_test=is_test, use_cudnn=use_cudnn)
 
-        self.fc_1_layer = FC(self.full_name(),
+        self.fc_1_layer = Linear( 768,
                              rnn_hidden_size * 3,
                              param_attr=para_attr,
-                             bias_attr=False,
-                             num_flatten_dims=2)
-        self.fc_2_layer = FC(self.full_name(),
+                             bias_attr=False )
+        print( "weight", self.fc_1_layer.weight.shape )
+        self.fc_2_layer = Linear( 768,
                              rnn_hidden_size * 3,
                              param_attr=para_attr,
-                             bias_attr=False,
-                             num_flatten_dims=2)
+                             bias_attr=False )
         self.gru_forward_layer = DynamicGRU(
-            self.full_name(),
             size=rnn_hidden_size,
             h_0=h_0,
             param_attr=para_attr,
             bias_attr=bias_attr,
             candidate_activation='relu')
         self.gru_backward_layer = DynamicGRU(
-            self.full_name(),
             size=rnn_hidden_size,
             h_0=h_0,
             param_attr=para_attr,
@@ -287,10 +275,9 @@ class EncoderNet(fluid.dygraph.Layer):
             candidate_activation='relu',
             is_reverse=True)
 
-        self.encoded_proj_fc = FC(self.full_name(),
+        self.encoded_proj_fc = Linear( rnn_hidden_size * 2,
                                   Config.decoder_size,
-                                  bias_attr=False,
-                                  num_flatten_dims=2)
+                                  bias_attr=False )
 
     def forward(self, inputs):
         conv_features = self.ocr_convs(inputs)
@@ -316,16 +303,15 @@ class EncoderNet(fluid.dygraph.Layer):
 
 
 class SimpleAttention(fluid.dygraph.Layer):
-    def __init__(self, scope_name, decoder_size):
-        super(SimpleAttention, self).__init__(scope_name)
+    def __init__(self, input_size, decoder_size):
+        super(SimpleAttention, self).__init__()
 
-        self.fc_1 = FC(self.full_name(),
+        self.fc_1 = Linear( input_size,
                        decoder_size,
                        act=None,
                        bias_attr=False)
-        self.fc_2 = FC(self.full_name(),
+        self.fc_2 = Linear( input_size,
                        1,
-                       num_flatten_dims = 2,
                        act=None,
                        bias_attr=False)
 
@@ -354,23 +340,22 @@ class SimpleAttention(fluid.dygraph.Layer):
 
 
 class GRUDecoderWithAttention(fluid.dygraph.Layer):
-    def __init__(self, scope_name, decoder_size, num_classes):
-        super(GRUDecoderWithAttention, self).__init__(scope_name)
-        self.simple_attention = SimpleAttention(self.full_name(), decoder_size)
+    def __init__(self,  decoder_size, num_classes):
+        super(GRUDecoderWithAttention, self).__init__()
+        self.simple_attention = SimpleAttention( decoder_size, decoder_size)
 
-        self.fc_1_layer = FC(self.full_name(),
-                             size=decoder_size * 3,
+        self.fc_1_layer = Linear( input_dim = 400,
+                             output_dim=decoder_size * 3,
                              bias_attr=False)
-        self.fc_2_layer = FC(self.full_name(),
-                             size=decoder_size * 3,
+        self.fc_2_layer = Linear( input_dim = decoder_size,
+                             output_dim=decoder_size * 3,
                              bias_attr=False)
         self.gru_unit = GRUUnit(
-            self.full_name(),
             size=decoder_size * 3,
             param_attr=None,
             bias_attr=None)
-        self.out_layer = FC(self.full_name(),
-                            size=num_classes + 2,
+        self.out_layer = Linear( input_dim = decoder_size,
+                            output_dim =num_classes + 2,
                             bias_attr=None,
                             act='softmax')
 
@@ -410,18 +395,18 @@ class GRUDecoderWithAttention(fluid.dygraph.Layer):
 
 
 class OCRAttention(fluid.dygraph.Layer):
-    def __init__(self, scope_name):
-        super(OCRAttention, self).__init__(scope_name)
-        self.encoder_net = EncoderNet(self.full_name())
-        self.fc = FC(self.full_name(),
-                     size=Config.decoder_size,
+    def __init__(self):
+        super(OCRAttention, self).__init__()
+        self.encoder_net = EncoderNet()
+        self.fc = Linear( input_dim = 200,
+                     output_dim =Config.decoder_size,
                      bias_attr=False,
                      act='relu')
         self.embedding = Embedding(
-            self.full_name(), [Config.num_classes + 2, Config.word_vector_dim],
+            [Config.num_classes + 2, Config.word_vector_dim],
             dtype='float32')
         self.gru_decoder_with_attention = GRUDecoderWithAttention(
-            self.full_name(), Config.decoder_size, Config.num_classes)
+            Config.decoder_size, Config.num_classes)
 
 
     def forward(self, inputs, label_in):
@@ -451,7 +436,7 @@ def train(args):
     with fluid.dygraph.guard():
         backward_strategy = fluid.dygraph.BackwardStrategy()
         backward_strategy.sort_sum_gradient = True
-        ocr_attention = OCRAttention("ocr_attention")
+        ocr_attention = OCRAttention()
 
         if Config.learning_rate_decay == "piecewise_decay":
             learning_rate = fluid.layers.piecewise_decay(

--- a/dygraph/ptb_lm/ptb_dy.py
+++ b/dygraph/ptb_lm/ptb_dy.py
@@ -42,13 +42,12 @@ if sys.version[0] == '2':
 
 class SimpleLSTMRNN(fluid.Layer):
     def __init__(self,
-                 name_scope,
                  hidden_size,
                  num_steps,
                  num_layers=2,
                  init_scale=0.1,
                  dropout=None):
-        super(SimpleLSTMRNN, self).__init__(name_scope)
+        super(SimpleLSTMRNN, self).__init__()
         self._hidden_size = hidden_size
         self._num_layers = num_layers
         self._init_scale = init_scale
@@ -132,14 +131,13 @@ class SimpleLSTMRNN(fluid.Layer):
 
 class PtbModel(fluid.Layer):
     def __init__(self,
-                 name_scope,
                  hidden_size,
                  vocab_size,
                  num_layers=2,
                  num_steps=20,
                  init_scale=0.1,
                  dropout=None):
-        super(PtbModel, self).__init__(name_scope)
+        super(PtbModel, self).__init__()
         self.hidden_size = hidden_size
         self.vocab_size = vocab_size
         self.init_scale = init_scale
@@ -147,14 +145,12 @@ class PtbModel(fluid.Layer):
         self.num_steps = num_steps
         self.dropout = dropout
         self.simple_lstm_rnn = SimpleLSTMRNN(
-            self.full_name(),
             hidden_size,
             num_steps,
             num_layers=num_layers,
             init_scale=init_scale,
             dropout=dropout)
         self.embedding = Embedding(
-            self.full_name(),
             size=[vocab_size, hidden_size],
             dtype='float32',
             is_sparse=False,
@@ -286,7 +282,6 @@ def train_ptb_lm():
             fluid.default_main_program().random_seed = seed
             max_epoch = 1
         ptb_model = PtbModel(
-            "ptb_model",
             hidden_size=hidden_size,
             vocab_size=vocab_size,
             num_layers=num_layers,


### PR DESCRIPTION
Now dygraph has three  incompatible upgrades.

- remove build_once
- change FC to Linear
- Optimizer must have parameter_list parameter

This PR ocr_recognition model for dygraph incompatible upgrade.