### PR TITLE
access public Parameters instead

### DIFF
--- a/PaddleNLP/Research/Dialogue-PLATO/plato/models/unified_transformer.py
+++ b/PaddleNLP/Research/Dialogue-PLATO/plato/models/unified_transformer.py
@@ -405,7 +405,7 @@ class UnifiedTransformer(ModelBase):
         if self.two_layer_predictor:
             dec_embed = self.pre_predictor(dec_embed)
         if self.weight_sharing:
-            token_embedding = self.embedder.token_embedding._w
+            token_embedding = self.embedder.token_embedding.weight
             dec_logits = layers.matmul(
                 x=dec_embed,
                 y=token_embedding,
@@ -648,7 +648,7 @@ class UnifiedTransformer(ModelBase):
         if self.two_layer_predictor:
             pred_embed = self.pre_predictor(pred_embed)
         if self.weight_sharing:
-            token_embedding = self.embedder.token_embedding._w
+            token_embedding = self.embedder.token_embedding.weight
             pred_logits = layers.matmul(
                 x=pred_embed,
                 y=token_embedding,

--- a/PaddleSpeech/DeepVoice3/deepvoice3_paddle/modules.py
+++ b/PaddleSpeech/DeepVoice3/deepvoice3_paddle/modules.py
@@ -384,7 +384,7 @@ class PositionEmbedding(dg.Layer):
             out (Variable): Shape(B, C_pos), position embedding, where C_pos 
                 means position embedding size.
         """
-        rad = fluid.layers.transpose(self.embed._w, perm=[1, 0])
+        rad = fluid.layers.transpose(self.embed.weight, perm=[1, 0])
         batch_size = indices.shape[0]
 
         if speaker_position_rate is None:

--- a/dygraph/transformer/model.py
+++ b/dygraph/transformer/model.py
@@ -640,7 +640,7 @@ class WrapDecoderLayer(Layer):
 
         if self._weight_sharing:
             predict = layers.matmul(x=dec_output_reshape,
-                                    y=self._prepare_decoder_layer._input_emb._w,
+                                    y=self._prepare_decoder_layer._input_emb.weight,
                                     transpose_y=True)
         else:
             predict = self._fc(dec_output_reshape)
@@ -693,7 +693,7 @@ class TransFormer(Layer):
             weight_sharing)
 
         if weight_sharing:
-            self._wrap_decoder_layer._prepare_decoder_layer._input_emb._w = self._wrap_encoder_layer._prepare_encoder_layer._input_emb._w
+            self._wrap_decoder_layer._prepare_decoder_layer._input_emb.weight = self._wrap_encoder_layer._prepare_encoder_layer._input_emb.weight
 
         self.n_layer = n_layer
         self.n_head = n_head


### PR DESCRIPTION
将访问私有field的参数改为访问public的，这些访问私有成员的方式1.7后不再支持。参见[这个PR](https://github.com/PaddlePaddle/Paddle/pull/21982)。