### PR TITLE
Add guide to new PaddleSlim repo in slim readme doc

### DIFF
--- a/PaddleSlim/README.md
+++ b/PaddleSlim/README.md
@@ -1,3 +1,7 @@
+# PaddleSlim新版本已经发布，项目已被迁移到： https://github.com/PaddlePaddle/PaddleSlim
+
+
+
 
 <div align="center">
   <h3>


### PR DESCRIPTION
Add guide to the new version of `PaddleSlim` in the readme document.