### PR TITLE
Fix repeat name error in se_resnet

### DIFF
--- a/dygraph/se_resnet/train.py
+++ b/dygraph/se_resnet/train.py
@@ -99,8 +99,7 @@ class ConvBNLayer(fluid.dygraph.Layer):
             padding=(filter_size - 1) // 2,
             groups=groups,
             act=None,
-            bias_attr=False,
-            param_attr=fluid.ParamAttr(name="weights"))
+            bias_attr=False)
 
         self._batch_norm = BatchNorm(num_filters, act=act)
 


### PR DESCRIPTION
https://github.com/PaddlePaddle/Paddle/pull/22140 add limit for repeat parameter name using in dygraph, se_resnet can't run correctly. fix it.