### PR TITLE
Fix transformer save_inference_model

### DIFF
--- a/PaddleNLP/PaddleMT/transformer/inference_model.py
+++ b/PaddleNLP/PaddleMT/transformer/inference_model.py
@@ -131,7 +131,7 @@ def do_save_inference_model(args):
 
     fluid.io.save_inference_model(
         args.inference_model_dir,
-        feeded_var_names=input_field_names,
+        feeded_var_names=list(input_field_names),
         target_vars=[out_ids, out_scores],
         executor=exe,
         main_program=test_prog,


### PR DESCRIPTION
The `feeded_var_names` of `save_inference_model` should be a list of `str` or will cause a `ValueError`. 
![image](https://user-images.githubusercontent.com/7160927/74700099-9127aa80-523d-11ea-937d-88f81bf0c672.png)