### PR TITLE
cherry-pick : do not print stack frame when train process killed (#4346)

### DIFF
--- a/PaddleCV/tracking/README.md
+++ b/PaddleCV/tracking/README.md
@@ -69,10 +69,12 @@ Datasets是数据集保存的路径。
 ## 快速开始
 
 tracking的工作环境：
+- Linux
 - python3
 - PaddlePaddle1.7
 
-> 注意：如果遇到cmath无法import的问题，建议切换Python版本，建议使用python3.6.8, python3.7.0
+> 注意：如果遇到cmath无法import的问题，建议切换Python版本，建议使用python3.6.8, python3.7.0 。另外，
+> tracking暂不支持在window上运行，如果开发者有需求在window上运行tracking，请在issue中提出需求。
 
 ### 安装依赖
 

--- a/PaddleCV/tracking/ltr/data/loader.py
+++ b/PaddleCV/tracking/ltr/data/loader.py
@@ -1,25 +1,8 @@
 import os
-import signal
 import sys
 
 import dataflow as df
 import numpy as np
-
-
-# handle terminate reader process, do not print stack frame
-def _reader_quit(signum, frame):
-    print("Reader process exit.")
-    sys.exit()
-
-
-def _term_group(sig_num, frame):
-    print('pid {} terminated, terminate group '
-          '{}...'.format(os.getpid(), os.getpgrp()))
-    os.killpg(os.getpgid(os.getpid()), signal.SIGKILL)
-
-
-signal.signal(signal.SIGTERM, _reader_quit)
-signal.signal(signal.SIGINT, _term_group)
 
 
 class LTRLoader(df.DataFlow):

--- a/PaddleCV/tracking/ltr/trainers/ltr_trainer.py
+++ b/PaddleCV/tracking/ltr/trainers/ltr_trainer.py
@@ -10,6 +10,25 @@ import paddle.fluid.dygraph as dygraph
 import time
 import numpy as np
 
+import sys
+import signal
+
+
+# handle terminate reader process, do not print stack frame
+def _reader_quit(signum, frame):
+    print("Reader process exit.")
+    sys.exit()
+
+
+def _term_group(sig_num, frame):
+    print('pid {} terminated, terminate group '
+          '{}...'.format(os.getpid(), os.getpgrp()))
+    os.killpg(os.getpgid(os.getpid()), signal.SIGKILL)
+
+
+signal.signal(signal.SIGTERM, _reader_quit)
+signal.signal(signal.SIGINT, _term_group)
+
 
 class LTRTrainer(BaseTrainer):
     def __init__(self, actor, loaders, optimizer, settings, lr_scheduler=None):


### PR DESCRIPTION
cherry-pick ，from  https://github.com/PaddlePaddle/models/pull/4346

fixed:
1. do not print stack frame when train process killed
2.  add note about VOT does not support windows OS