### PR TITLE
add .encode('utf-8') to fix predict outputs

### DIFF
--- a/dygraph/lac/predict.py
+++ b/dygraph/lac/predict.py
@@ -80,7 +80,7 @@ def do_infer(args):
         result = infer_process(infer_loader)
         for sent, tags in result:
             result_list = ['(%s, %s)' % (ch, tag) for ch, tag in zip(sent, tags)]
-            print(''.join(result_list))
+            print(''.join(result_list).encode('utf-8'))
 
 if __name__ == '__main__':
     args = parser.parse_args()


### PR DESCRIPTION
paddle：1.7
python：3.7
sh predict.sh
![image](https://user-images.githubusercontent.com/17399203/76603639-45b8a180-6548-11ea-86ec-1d21c1d757b3.png)

Fix:
add .encode('utf-8') to fix predict outputs