### PR TITLE
fit for new GradMaker

### DIFF
--- a/PaddleCV/Paddle3D/PointNet++/ext_op/src/gather_point_op.cc
+++ b/PaddleCV/Paddle3D/PointNet++/ext_op/src/gather_point_op.cc
@@ -94,15 +94,13 @@ public:
   using framework::SingleGradOpMaker<T>::SingleGradOpMaker;
 
 protected:
-  std::unique_ptr<T> Apply() const override {
-    auto* op = new T();
+  void Apply(GradOpPtr<T> op) const override {
     op->SetType("gather_point_grad");
     op->SetInput("X", this->Input("X"));
     op->SetInput("Index", this->Input("Index"));
     op->SetInput(framework::GradVarName("Output"), this->OutputGrad("Output"));
     op->SetOutput(framework::GradVarName("X"), this->InputGrad("X"));
     op->SetAttrMap(this->Attrs());
-    return std::unique_ptr<T>(op);
   }
 };
 

--- a/PaddleCV/Paddle3D/PointNet++/ext_op/src/group_points_op.cc
+++ b/PaddleCV/Paddle3D/PointNet++/ext_op/src/group_points_op.cc
@@ -102,15 +102,13 @@ class GroupPointsGradDescMaker : public framework::SingleGradOpMaker<T> {
   using framework::SingleGradOpMaker<T>::SingleGradOpMaker;
 
  protected:
-  std::unique_ptr<T> Apply() const override {
-    auto* op = new T();
+  void Apply(GradOpPtr<T> op) const override {
     op->SetType("group_points_grad");
     op->SetInput("X", this->Input("X"));
     op->SetInput("Idx", this->Input("Idx"));
     op->SetInput(framework::GradVarName("Out"), this->OutputGrad("Out"));
     op->SetOutput(framework::GradVarName("X"), this->InputGrad("X"));
     op->SetAttrMap(this->Attrs());
-    return std::unique_ptr<T>(op);
   }
 };
 

--- a/PaddleCV/Paddle3D/PointNet++/ext_op/src/three_interp_op.cc
+++ b/PaddleCV/Paddle3D/PointNet++/ext_op/src/three_interp_op.cc
@@ -117,8 +117,7 @@ public:
   using framework::SingleGradOpMaker<T>::SingleGradOpMaker;
 
 protected:
-  std::unique_ptr<T> Apply() const override {
-    auto* op = new T();
+  void Apply(GradOpPtr<T> op) const override {
     op->SetType("three_interp_grad");
     op->SetInput("X", this->Input("X"));
     op->SetInput("Weight", this->Input("Weight"));
@@ -126,7 +125,6 @@ protected:
     op->SetInput(framework::GradVarName("Out"), this->OutputGrad("Out"));
     op->SetOutput(framework::GradVarName("X"), this->InputGrad("X"));
     op->SetAttrMap(this->Attrs());
-    return std::unique_ptr<T>(op);
   }
 };
 


### PR DESCRIPTION
**Paddle3D ext_op fit for new GradMaker**
- `GradMaker::Apply` has changed since https://github.com/PaddlePaddle/Paddle/pull/22457 merged to `develop`
- `release/1.7` not need to fit