### PR TITLE
fix models because the gradient clip strategy has been upgraded

### DIFF
--- a/PaddleCV/ocr_recognition/crnn_ctc_model.py
+++ b/PaddleCV/ocr_recognition/crnn_ctc_model.py
@@ -60,20 +60,16 @@ def conv_bn_pool(input,
 
 def ocr_convs(input,
               regularizer=None,
-              gradient_clip=None,
               is_test=False,
               use_cudnn=False):
     b = fluid.ParamAttr(
         regularizer=regularizer,
-        gradient_clip=gradient_clip,
         initializer=fluid.initializer.Normal(0.0, 0.0))
     w0 = fluid.ParamAttr(
         regularizer=regularizer,
-        gradient_clip=gradient_clip,
         initializer=fluid.initializer.Normal(0.0, 0.0005))
     w1 = fluid.ParamAttr(
         regularizer=regularizer,
-        gradient_clip=gradient_clip,
         initializer=fluid.initializer.Normal(0.0, 0.01))
     tmp = input
     tmp = conv_bn_pool(
@@ -119,7 +115,6 @@ def encoder_net(images,
     conv_features = ocr_convs(
         images,
         regularizer=regularizer,
-        gradient_clip=gradient_clip,
         is_test=is_test,
         use_cudnn=use_cudnn)
     sliced_feature = fluid.layers.im2sequence(
@@ -163,11 +158,9 @@ def encoder_net(images,
 
     w_attr = fluid.ParamAttr(
         regularizer=regularizer,
-        gradient_clip=gradient_clip,
         initializer=fluid.initializer.Normal(0.0, 0.02))
     b_attr = fluid.ParamAttr(
         regularizer=regularizer,
-        gradient_clip=gradient_clip,
         initializer=fluid.initializer.Normal(0.0, 0.0))
 
     fc_out = fluid.layers.fc(input=[gru_forward, gru_backward],


### PR DESCRIPTION
梯度裁剪的策略在2.0中已经升级  https://github.com/PaddlePaddle/Paddle/pull/23224

移除了fluid.ParamAttr中对gradient_clip的设置。

目前encoder_net在crnn_ctc_model.py中使用了三处，均未设置gradient_clip，是默认参数None，因此直接删除没有影响。

![image](https://user-images.githubusercontent.com/52485244/78755778-4eb45b80-79ac-11ea-9cb9-cb44088738a3.png)


![image](https://user-images.githubusercontent.com/52485244/78755772-4a883e00-79ac-11ea-8c54-1a77b3eb6d28.png)



