### PR TITLE
fix no print in dygraph/lac

### DIFF
--- a/dygraph/lac/run.sh
+++ b/dygraph/lac/run.sh
@@ -9,9 +9,9 @@ python -m paddle.distributed.launch  --selected_gpus=0,1,2,3 train.py \
         --test_data ./data/test.tsv \
         --model_save_dir ./padding_models \
         --validation_steps 1000 \
-        --save_steps 10000 \
-        --print_steps 200 \
-        --batch_size 400 \
+        --save_steps 1 \
+        --print_steps 1 \
+        --batch_size 32 \
         --epoch 10 \
         --traindata_shuffle_buffer 20000 \
         --word_emb_dim 128 \


### PR DESCRIPTION
Downloaded train.tsv is very small, so we need to decrease batch_size, print_steps and save_steps to enable logging and saving checkpoints.