### PR TITLE
ocr_recognition的train.py更新：断点训练加载模型时缺少参数 “exe”

### DIFF
--- a/PaddleCV/ocr_recognition/train.py
+++ b/PaddleCV/ocr_recognition/train.py
@@ -106,7 +106,7 @@ def train(args):
     # load init model
     if args.init_model is not None:
         model_dir = args.init_model
-        fluid.load(fluid.default_main_program(), model_dir)
+        fluid.load(fluid.default_main_program(), model_dir, exe)
         print("Init model from: %s." % args.init_model)
 
     train_exe = exe


### PR DESCRIPTION
ocr_recognition的train.py代码（release 1.7）第109行fluid.load()缺少第三个参数"exe"，正确的写法如下：
    # load init model
    if args.init_model is not None:
        model_dir = args.init_model
        fluid.load(fluid.default_main_program(), model_dir, exe)
        print("Init model from: %s." % args.init_model)
若不加“exe”参数，加载已训练的模型进行断点训练时将会有如下报错：
AttributeError: 'NoneType' object has no attribute 'get_tensor'