### PR TITLE
Update Pix2pix_network.py：dropout下，updeconv未被更新

### DIFF
--- a/PaddleCV/gan/network/Pix2pix_network.py
+++ b/PaddleCV/gan/network/Pix2pix_network.py
@@ -335,7 +335,7 @@ def Unet_block(inputunet,
             use_bias=use_bias)
 
         if use_dropout:
-            upnorm = fluid.layers.dropout(upnorm, dropout_prob=0.5)
+            updeconv = fluid.layers.dropout(upnorm, dropout_prob=0.5)
         return fluid.layers.concat([inputunet, updeconv], 1)
 
 


### PR DESCRIPTION
在 `dropout` 下, `updeconv`参数没有被更新，将 `upnorm` 改为 `updeconv`