### PR TITLE
fix resnet50 usetime statistics

### DIFF
--- a/PaddleCV/image_classification/train.py
+++ b/PaddleCV/image_classification/train.py
@@ -252,7 +252,8 @@ def train(args):
             t2 = time.time()
             train_batch_elapse = t2 - t1
             train_batch_time_record.append(train_batch_elapse)
-            train_batch_metrics_avg = np.mean(
+           
+	    train_batch_metrics_avg = np.mean(
                 np.array(train_batch_metrics), axis=1)
             train_batch_metrics_record.append(train_batch_metrics_avg)
             if trainer_id == 0:
@@ -263,7 +264,7 @@ def train(args):
                         train_batch_time_print_step_avg = np.mean(train_batch_time_print_step)
                     train_batch_time_print_step = []
                     print_info("batch", train_batch_metrics_avg, train_batch_time_print_step_avg,
-                           pass_id, train_batch_id, args.print_step)
+           	                pass_id, train_batch_id, args.print_step)
                 else:
                     train_batch_time_print_step.append(train_batch_elapse)
 

--- a/PaddleCV/image_classification/train.py
+++ b/PaddleCV/image_classification/train.py
@@ -234,6 +234,7 @@ def train(args):
         train_batch_id = 0
         train_batch_time_record = []
         train_batch_metrics_record = []
+        train_batch_time_print_step = []
 
         if not args.use_dali:
             train_iter = train_data_loader()
@@ -251,13 +252,21 @@ def train(args):
             t2 = time.time()
             train_batch_elapse = t2 - t1
             train_batch_time_record.append(train_batch_elapse)
-
             train_batch_metrics_avg = np.mean(
                 np.array(train_batch_metrics), axis=1)
             train_batch_metrics_record.append(train_batch_metrics_avg)
             if trainer_id == 0:
-                print_info("batch", train_batch_metrics_avg, train_batch_elapse,
+		if train_batch_id % args.print_step == 0:
+		    if len(train_batch_time_print_step) == 0:
+			train_batch_time_print_step_avg = train_batch_elapse
+		    else:
+                        train_batch_time_print_step_avg = np.mean(train_batch_time_print_step)
+                    train_batch_time_print_step = []
+                    print_info("batch", train_batch_metrics_avg, train_batch_time_print_step_avg,
                            pass_id, train_batch_id, args.print_step)
+                else:
+                    train_batch_time_print_step.append(train_batch_elapse)
+
                 sys.stdout.flush()
             train_batch_id += 1
             t1 = time.time()

--- a/PaddleCV/image_classification/train.py
+++ b/PaddleCV/image_classification/train.py
@@ -252,19 +252,21 @@ def train(args):
             t2 = time.time()
             train_batch_elapse = t2 - t1
             train_batch_time_record.append(train_batch_elapse)
-           
-	    train_batch_metrics_avg = np.mean(
+
+            train_batch_metrics_avg = np.mean(
                 np.array(train_batch_metrics), axis=1)
             train_batch_metrics_record.append(train_batch_metrics_avg)
             if trainer_id == 0:
-		if train_batch_id % args.print_step == 0:
-		    if len(train_batch_time_print_step) == 0:
-			train_batch_time_print_step_avg = train_batch_elapse
-		    else:
-                        train_batch_time_print_step_avg = np.mean(train_batch_time_print_step)
+                if train_batch_id % args.print_step == 0:
+                    if len(train_batch_time_print_step) == 0:
+                        train_batch_time_print_step_avg = train_batch_elapse
+                    else:
+                        train_batch_time_print_step_avg = np.mean(
+                            train_batch_time_print_step)
                     train_batch_time_print_step = []
-                    print_info("batch", train_batch_metrics_avg, train_batch_time_print_step_avg,
-           	                pass_id, train_batch_id, args.print_step)
+                    print_info("batch", train_batch_metrics_avg,
+                               train_batch_time_print_step_avg, pass_id,
+                               train_batch_id, args.print_step)
                 else:
                     train_batch_time_print_step.append(train_batch_elapse)
 


### PR DESCRIPTION
Fetch优化后，resnet50、resnet101Benchmark性能突增，原因是模型运行时间统计方式错误。

## 一、Paddle背景情况说明
Paddle exe.run()并非是完整的完成一轮训练返回，而是在成功Fetch用户所需数据后即返回。但有两种场景会通过cudaStreamSynchronize等待所有Kernel执行完成，exe.run()才返回：
1）DropLocalExeScopes清理Scope时；
2）ParallelExecutor析构时；
因此，可能会出现有的exe.run()很快，有些exe.run()很慢的情况。如下图所示：

![图片](https://agroup-bos-bj.cdn.bcebos.com/bj-1c9a761cf61f2d1c6fbc79c33fb2b6d59e7f29e5)
*注：图中，第1轮用时=第1轮前向计算用时，第10轮用时=第9轮反向用时+第10轮前向用时+第10轮反向用时。*
因此，Paddle中exe.run()的时间，可能是不均衡的。

## 二、Fetch修改对Resnet影响
Fetch修改前Resnet50的timeline如下：
![图片](https://agroup-bos-bj.cdn.bcebos.com/bj-ad0c00cb938bf5f3537dc3f72a31c88ad5976a76)
修改后如下：
![图片](https://agroup-bos-bj.cdn.bcebos.com/bj-dd65699795f26e9aebff1646c37d8b4885d4a0e9)
- Fetch修改前，由于Fetch阻塞，导致exe.run()不能提早结束。因此每轮exe.run()时间都等于其前向时间+反向时间。
-  而修改后，出现了exe.run()时间不均衡。
- 由于exec_strategy.num_iteration_per_drop_scope设置为10。因此，每10轮中，第1轮耗时短，第10轮耗时长，其余8轮时间基本均衡。

## 三、时间统计漏洞
Benchmark通过抓取模型日志中的耗时，计算speed。
**Resnet模型print_step=10，而且每次只打印最后一轮耗时，而非10轮的平均值。**
恰好每次都统计到了耗时短的一次，造成了性能的假突增：
![图片](https://agroup-bos-bj.cdn.bcebos.com/bj-9a140ec4fabd490e43240ca0fe80229a36e09ee6)

## 四、Fetch修改前后，实际性能情况
|模型 | 修改前（800setp总时间） | 修改后 | 性能提升 | 
|---|---|---|---|
|Resnet50<input type="checkbox" class="rowselector hidden"> | 84.8940119743 | 83.2191288471 | 1.97% | 
|Resnet101 | 135.613070011 | 135.286768198 | 0.24% | 