### PR TITLE
[cherry-pick] Update mpii_reader.py

### DIFF
--- a/PaddleCV/human_pose_estimation/lib/mpii_reader.py
+++ b/PaddleCV/human_pose_estimation/lib/mpii_reader.py
@@ -183,7 +183,7 @@ def _reader_creator(root, image_set, shuffle=False, is_train=False):
                         test_mode=False,
                         imagenum=0)
         else:
-            fold = 'test'
+            fold = cfg.DATAROOT + os.sep + cfg.IMAGEDIR + os.sep + 'test'
             for img_name in os.listdir(fold):
                 yield dict(image=os.path.join(fold, img_name),
                            filename=img_name)

--- a/PaddleCV/human_pose_estimation/lib/mpii_reader.py
+++ b/PaddleCV/human_pose_estimation/lib/mpii_reader.py
@@ -183,7 +183,7 @@ def _reader_creator(root, image_set, shuffle=False, is_train=False):
                         test_mode=False,
                         imagenum=0)
         else:
-            fold = cfg.DATAROOT + os.sep + cfg.IMAGEDIR + os.sep + 'test'
+            fold = os.path.join(cfg.DATAROOT, cfg.IMAGEDIR, 'test')
             for img_name in os.listdir(fold):
                 yield dict(image=os.path.join(fold, img_name),
                            filename=img_name)


### PR DESCRIPTION
cherry-pick from https://github.com/PaddlePaddle/models/pull/4862

操作系统: win10
python版本: 3.6.10
问题描述:
human_pose_estimation使用mpii数据集test的时候一直没有运行结果。在问题文件186行
fold = ‘test’
修改为
fold = cfg.DATAROOT + os.sep + cfg.IMAGEDIR + os.sep  +'test'
之后可以运行，因为下一行os.listdir(fold)读取的路径不对，根目录下没有叫test的文件夹，所以一直读取0张图片，正确路径是data/mpii/images下的test文件夹。
对应issue链接:
https://github.com/PaddlePaddle/models/issues/4859#event-3781128059