### PR TITLE
fix resnet dygraph model time print

### DIFF
--- a/dygraph/resnet/train.py
+++ b/dygraph/resnet/train.py
@@ -143,19 +143,24 @@ def parse_args():
 args = parse_args()
 batch_size = args.batch_size
 
+
 class TimeCostAverage(object):
     def __init__(self):
         self.reset()
+
     def reset(self):
         self.cnt = 0
         self.total_time = 0
+
     def record(self, usetime):
         self.cnt += 1
         self.total_time += usetime
+
     def get_average(self):
         if self.cnt == 0:
             return 0
         return self.total_time / self.cnt
+
 
 def optimizer_setting(parameter_list=None):
 
@@ -493,7 +498,8 @@ def train_resnet():
                         "[Epoch %d, batch %d] loss %.5f, acc1 %.5f, acc5 %.5f, batch_cost: %.5f s, reader_cost: %.5f s"
                         % (eop, batch_id, total_loss / total_sample,
                            total_acc1 / total_sample, total_acc5 / total_sample,
-                           train_batch_cost_avg.get_average(), train_reader_cost_avg.get_average()))
+                           train_batch_cost_avg.get_average(),
+                           train_reader_cost_avg.get_average()))
                     train_batch_cost_avg.reset()
                     train_reader_cost_avg.reset()
                 batch_start = time.time()

--- a/dygraph/resnet/train.py
+++ b/dygraph/resnet/train.py
@@ -143,6 +143,19 @@ def parse_args():
 args = parse_args()
 batch_size = args.batch_size
 
+class TimeCostAverage(object):
+    def __init__(self):
+        self.reset()
+    def reset(self):
+        self.cnt = 0
+        self.total_time = 0
+    def record(self, usetime):
+        self.cnt += 1
+        self.total_time += usetime
+    def get_average(self):
+        if self.cnt == 0:
+            return 0
+        return self.total_time / self.cnt
 
 def optimizer_setting(parameter_list=None):
 
@@ -433,6 +446,8 @@ def train_resnet():
             total_acc5 = 0.0
             total_sample = 0
 
+            train_batch_cost_avg = TimeCostAverage()
+            train_reader_cost_avg = TimeCostAverage()
             batch_start = time.time()
             for batch_id, data in enumerate(train_loader()):
                 #NOTE: used in benchmark
@@ -469,13 +484,18 @@ def train_resnet():
                 total_sample += 1
 
                 train_batch_cost = time.time() - batch_start
+                train_batch_cost_avg.record(train_batch_cost)
+                train_reader_cost_avg.record(train_reader_cost)
+
                 total_batch_num = total_batch_num + 1  #this is for benchmark
                 if batch_id % 10 == 0:
                     print(
                         "[Epoch %d, batch %d] loss %.5f, acc1 %.5f, acc5 %.5f, batch_cost: %.5f s, reader_cost: %.5f s"
                         % (eop, batch_id, total_loss / total_sample,
                            total_acc1 / total_sample, total_acc5 / total_sample,
-                           train_batch_cost, train_reader_cost))
+                           train_batch_cost_avg.get_average(), train_reader_cost_avg.get_average()))
+                    train_batch_cost_avg.reset()
+                    train_reader_cost_avg.reset()
                 batch_start = time.time()
 
             if args.ce:


### PR DESCRIPTION
根据近期共识的，新的性能统计规范修改了resnet model：

1. batch_time = reader time + exe.run time
2. 求log_interval步的平均时间

本模型有四个时间，train_batch_cost，train_reader_cost，这两个时间的计算都是正确的，只是没有取平均。因此，本PR对这两个时间再求log_interval步的平均