### PR TITLE
add ips for dygraph mobilenet and resnet models

### DIFF
--- a/dygraph/mobilenet/train.py
+++ b/dygraph/mobilenet/train.py
@@ -38,19 +38,24 @@ args = parse_args()
 if int(os.getenv("PADDLE_TRAINER_ID", 0)) == 0:
     print_arguments(args)
 
+
 class TimeCostAverage(object):
     def __init__(self):
         self.reset()
+
     def reset(self):
         self.cnt = 0
         self.total_time = 0
+
     def record(self, usetime):
         self.cnt += 1
         self.total_time += usetime
+
     def get_average(self):
         if self.cnt == 0:
             return 0
         return self.total_time / self.cnt
+
 
 def eval(net, test_data_loader, eop):
     total_loss = 0.0
@@ -232,13 +237,14 @@ def train_mobilenet():
 
                 total_batch_num = total_batch_num + 1
                 if batch_id % args.print_step == 0:
+                    ips = float(args.batch_size) / batch_cost_avg.get_average()
                     print(
-                        "[Epoch %d, batch %d], avg_loss %.5f, acc_top1 %.5f, acc_top5 %.5f, batch_cost: %.5f s, net_t: %.5f s, backward_t: %.5f s, reader_t: %.5f s"
+                        "[Epoch %d, batch %d], avg_loss %.5f, acc_top1 %.5f, acc_top5 %.5f, batch_cost: %.5f s, net_t: %.5f s, backward_t: %.5f s, reader_t: %.5f s, ips: %.5f images/sec"
                         % (eop, batch_id, avg_loss.numpy(), acc_top1.numpy(),
                            acc_top5.numpy(), batch_cost_avg.get_average(),
                            batch_net_avg.get_average(),
                            batch_backward_avg.get_average(),
-                           batch_reader_avg.get_average()))
+                           batch_reader_avg.get_average(), ips))
                     sys.stdout.flush()
                     batch_cost_avg.reset()
                     batch_net_avg.reset()

--- a/dygraph/resnet/train.py
+++ b/dygraph/resnet/train.py
@@ -494,12 +494,14 @@ def train_resnet():
 
                 total_batch_num = total_batch_num + 1  #this is for benchmark
                 if batch_id % 10 == 0:
+                    ips = float(
+                        args.batch_size) / train_batch_cost_avg.get_average()
                     print(
-                        "[Epoch %d, batch %d] loss %.5f, acc1 %.5f, acc5 %.5f, batch_cost: %.5f s, reader_cost: %.5f s"
+                        "[Epoch %d, batch %d] loss %.5f, acc1 %.5f, acc5 %.5f, batch_cost: %.5f s, reader_cost: %.5f s, ips: %.5f images/sec"
                         % (eop, batch_id, total_loss / total_sample,
                            total_acc1 / total_sample, total_acc5 / total_sample,
                            train_batch_cost_avg.get_average(),
-                           train_reader_cost_avg.get_average()))
+                           train_reader_cost_avg.get_average(), ips))
                     train_batch_cost_avg.reset()
                     train_reader_cost_avg.reset()
                 batch_start = time.time()


### PR DESCRIPTION
增加IPS输出：
- mobilenet-V1：在CPU上运行，batch_size=4，输出如下：
```
[Epoch 0, batch 10], avg_loss 0.00000, acc_top1 1.00000, acc_top5 1.00000, batch_cost: 1.33183 s, net_t: 0.44647 s, backward_t: 0.78070 s, reader_t: 0.04040 s, ips: 3.00338 images/sec
[Epoch 0, batch 20], avg_loss 0.00000, acc_top1 1.00000, acc_top5 1.00000, batch_cost: 1.23914 s, net_t: 0.40186 s, backward_t: 0.78185 s, reader_t: 0.00170 s, ips: 3.22804 images/sec
[Epoch 0, batch 30], avg_loss 0.00000, acc_top1 1.00000, acc_top5 1.00000, batch_cost: 1.21990 s, net_t: 0.38759 s, backward_t: 0.77668 s, reader_t: 0.00150 s, ips: 3.27896 images/sec
[Epoch 0, batch 40], avg_loss 0.00000, acc_top1 1.00000, acc_top5 1.00000, batch_cost: 1.25072 s, net_t: 0.40059 s, backward_t: 0.79487 s, reader_t: 0.00151 s, ips: 3.19816 images/sec
```
- resnet： 在CPU上运行，batch_size=2，输出如下：
```
[Epoch 0, batch 0] loss 4.64205, acc1 0.00000, acc5 0.00000, batch_cost: 4.26375 s, reader_cost: 0.46242 s, ips: 0.46907 images/sec
[Epoch 0, batch 10] loss 44.68754, acc1 0.00000, acc5 0.00000, batch_cost: 2.80404 s, reader_cost: 0.00015 s, ips: 0.71326 images/sec
[Epoch 0, batch 20] loss 29.44468, acc1 0.02381, acc5 0.02381, batch_cost: 2.85184 s, reader_cost: 0.00013 s, ips: 0.70130 images/sec
```