### PR TITLE
pad input to use tensor core

### DIFF
--- a/PaddleCV/image_classification/reader.py
+++ b/PaddleCV/image_classification/reader.py
@@ -245,6 +245,9 @@ def process_image(sample, settings, mode, color_jitter, rotate):
     img_std = np.array(std).reshape((3, 1, 1))
     img -= img_mean
     img /= img_std
+    if settings.image_shape[0] == 4:
+        pad0 = np.zeros((1, img.shape[1], img.shape[2]))
+        img = np.concatenate((img, pad0), axis=0)
     # doing training (train.py)
     if mode == 'train' or (mode == 'val' and
                            not hasattr(settings, 'save_json_path')):

--- a/PaddleCV/image_classification/scripts/train/ResNet50_fp16.sh
+++ b/PaddleCV/image_classification/scripts/train/ResNet50_fp16.sh
@@ -19,7 +19,7 @@ python train.py \
        --data_dir=${DATA_DIR} \
        --batch_size=256 \
        --total_images=1281167 \
-       --image_shape 3 224 224 \
+       --image_shape 4 224 224 \
        --class_dim=1000 \
        --print_step=10 \
        --model_save_dir=output/ \


### PR DESCRIPTION
在开启dali的同时，输入shape修改为[4, 224, 224]，会自动对通道进行pad。
4通道下，第一层卷积能够利用tensor core加速，模型提速6.4%