### PR TITLE
Fix typo in log

### DIFF
--- a/dygraph/transformer/train.py
+++ b/dygraph/transformer/train.py
@@ -201,7 +201,7 @@ def do_train(args):
                         logger.info(
                             "step_idx: %d, epoch: %d, batch: %d, avg loss: %f, "
                             "normalized loss: %f, ppl: %f, avg_speed: %.2f step/s, "
-                            "words speed: %0.2f works/s" %
+                            "words speed: %0.2f words/s" %
                             (step_idx, pass_id, batch_id, total_avg_cost,
                              total_avg_cost - loss_normalizer,
                              np.exp([min(total_avg_cost, 100)]),


### PR DESCRIPTION
Fix typo in log, from `works` to `words`. 