### PR TITLE
fix tsn benchmark

### DIFF
--- a/dygraph/tsn/model.py
+++ b/dygraph/tsn/model.py
@@ -246,7 +246,7 @@ class TSN_ResNet(paddle.nn.Layer):
             self.class_dim,
             weight_attr=ParamAttr(
                 initializer=paddle.nn.initializer.Normal(
-                    loc=0.0, scale=0.01),
+                    mean=0.0, std=0.01),
                 name="fc_0.w_0"),
             bias_attr=ParamAttr(
                 initializer=paddle.nn.initializer.Constant(value=0.0),

--- a/dygraph/tsn/train.py
+++ b/dygraph/tsn/train.py
@@ -161,7 +161,7 @@ def create_optimizer(cfg, params):
     momentum = cfg.momentum
 
     optimizer = paddle.optimizer.Momentum(
-        learning_rate=paddle.optimizer.PiecewiseLR(
+        learning_rate=paddle.optimizer.lr.PiecewiseDecay(
             boundaries=bd, values=lr),
         momentum=momentum,
         weight_decay=paddle.regularizer.L2Decay(l2_weight_decay),
@@ -190,7 +190,7 @@ def train(args):
 
         video_model = paddle.DataParallel(video_model)
     
-    pre_state_dict, _ = paddle.load(args.pretrain)
+    pre_state_dict = paddle.load(args.pretrain)
     #if paddle.distributed.parallel.Env().local_rank == 0:
     video_model = init_model(video_model, pre_state_dict)
 


### PR DESCRIPTION
Changes:
In norm function: Attribute: loc and sth. change to std and mean, they are back now.
paddle.load only deal with one kind of inputs, either opt parms or weight params, BIG improvement!
almost forget this: PiecewiseLR is named to PiecewiseDecay, again, so philosophy.
It is a sort of meaningful PR, really, our semi-auto benchmark platform will smoothy run now except for another API changes in the future :)