### PR TITLE
Alter the default value for vocab

### DIFF
--- a/PaddleNLP/paddlenlp/data/vocab.py
+++ b/PaddleNLP/paddlenlp/data/vocab.py
@@ -36,14 +36,14 @@ class Vocab(object):
             between tokens and indices to be used. If provided, adjust the tokens
             and indices mapping according to it. If None, counter must be provided.
             Default: None.
-        unk_token (str): special token for unknow token. If no need, it also
-            could be None. Default: '<unk>'.
-        pad_token (str): special token for padding token. If no need, it also
-            could be None. Default: '<pad>'.
-        bos_token (str): special token for bos token. If no need, it also
-            could be None. Default: <bos>'.
-        eos_token (str): special token for eos token. If no need, it also
-            could be None. Default: '<eos>'.
+        unk_token (str): special token for unknow token '<unk>'. If no need, it also
+            could be None. Default: None.
+        pad_token (str): special token for padding token '<pad>'. If no need, it also
+            could be None. Default: None.
+        bos_token (str): special token for bos token '<bos>'. If no need, it also
+            could be None. Default: None.
+        eos_token (str): special token for eos token '<eos>'. If no need, it also
+            could be None. Default: None.
         **kwargs (dict): Keyword arguments ending with `_token`. It can be used
             to specify further special tokens that will be exposed as attribute
             of the vocabulary and associated with an index.
@@ -54,10 +54,10 @@ class Vocab(object):
                  max_size=None,
                  min_freq=1,
                  token_to_idx=None,
-                 unk_token='<unk>',
-                 pad_token='<pad>',
-                 bos_token='<bos>',
-                 eos_token='<eos>',
+                 unk_token=None,
+                 pad_token=None,
+                 bos_token=None,
+                 eos_token=None,
                  **kwargs):
         # Handle special tokens
         combs = (('unk_token', unk_token), ('pad_token', pad_token),
@@ -317,10 +317,10 @@ class Vocab(object):
                     max_size=None,
                     min_freq=1,
                     token_to_idx=None,
-                    unk_token='<unk>',
-                    pad_token='<pad>',
-                    bos_token='<bos>',
-                    eos_token='<eos>',
+                    unk_token=None,
+                    pad_token=None,
+                    bos_token=None,
+                    eos_token=None,
                     **kwargs):
         """
         Building vocab accoring to given iterator and other information. Iterate
@@ -333,14 +333,14 @@ class Vocab(object):
                 between tokens and indices to be used. If provided, adjust the tokens
                 and indices mapping according to it. If None, counter must be provided.
                 Default: None.
-            unk_token (str): special token for unknow token. If no need, it also
-                could be None. Default: '<unk>'.
-            pad_token (str): special token for padding token. If no need, it also
-                could be None. Default: '<pad>'.
-            bos_token (str): special token for bos token. If no need, it also
-                could be None. Default: <bos>'.
-            eos_token (str): special token for eos token. If no need, it also
-                could be None. Default: '<eos>'.
+            unk_token (str): special token for unknow token '<unk>'. If no need, it also
+                could be None. Default: None.
+            pad_token (str): special token for padding token '<pad>'. If no need, it also
+                could be None. Default: None.
+            bos_token (str): special token for bos token '<bos>'. If no need, it also
+                could be None. Default: None.
+            eos_token (str): special token for eos token '<eos>'. If no need, it also
+                could be None. Default: None.
             **kwargs (dict): Keyword arguments ending with `_token`. It can be used
                 to specify further special tokens that will be exposed as attribute
                 of the vocabulary and associated with an index.


### PR DESCRIPTION
修改 `class Vocab` 和 `def build_vocab` special token 的默认值为 None。
若用户无需使用 special token，可以不用显式地传入 None。
同时也和 `load_vocabulary` 和 `from_dict` 统一。

目前 PaddleNLP 下没有使用 `Vocab()` 或是 `Vocab` 下的 `build_vocab()` 获取词表的地方。
![image](https://user-images.githubusercontent.com/7160927/102296625-b9c91f80-3f88-11eb-9acb-829cc064ed38.png)
![image](https://user-images.githubusercontent.com/7160927/102296719-e846fa80-3f88-11eb-85f1-030009be7d32.png)

