### PR TITLE
support AMP training

### DIFF
--- a/PaddleNLP/benchmark/transformer/configs/transformer.base.yaml
+++ b/PaddleNLP/benchmark/transformer/configs/transformer.base.yaml
@@ -96,9 +96,10 @@ dropout: 0.1
 # Vocabularies in source and target should be same for weight sharing.
 weight_sharing: True
 
-# Use amp or not
+# Mixed precision training
 use_amp: False
-scale_loss: 1.0
+use_pure_fp16: False
+scale_loss: 128.0
 
 # Whether to use multi-card/multi-node distributed training.
 # Only works for static graph for now.

--- a/PaddleNLP/benchmark/transformer/configs/transformer.big.yaml
+++ b/PaddleNLP/benchmark/transformer/configs/transformer.big.yaml
@@ -7,7 +7,7 @@ init_from_checkpoint: ""
 # Path of the pretrain model, to better solve the current task
 init_from_pretrain_model: ""
 # Path of trained parameter, to make prediction
-init_from_params: "./trained_models/step_final/"
+init_from_params: "./trained_models/step_450000/"
 # The directory for saving model
 save_model: "trained_models"
 # Set seed for CE or debug
@@ -31,7 +31,7 @@ scale_loss: 128.0
 pool_size: 200000
 sort_type: "global"
 batch_size: 5120
-infer_batch_size: 16
+infer_batch_size: 8
 shuffle_batch: True
 # Data shuffle only works when sort_type is pool or none
 shuffle: True

--- a/PaddleNLP/benchmark/transformer/configs/transformer.big.yaml
+++ b/PaddleNLP/benchmark/transformer/configs/transformer.big.yaml
@@ -17,19 +17,20 @@ output_file: "predict.txt"
 # The <bos>, <eos> and <unk> tokens in the dictionary.
 special_token: ["<s>", "<e>", "<unk>"]
 # The directory to store data.
-root: None
+root: "/workspace/models-1/PaddleNLP/benchmark/transformer/"
 
 # Whether to use cuda
 use_gpu: True
 
 # Mixed precision training
 use_amp: True
+use_pure_fp16: True
 scale_loss: 128.0
 
 # Args for reader, see reader.py for details
 pool_size: 200000
 sort_type: "global"
-batch_size: 4096
+batch_size: 5120
 infer_batch_size: 16
 shuffle_batch: True
 # Data shuffle only works when sort_type is pool or none
@@ -71,7 +72,7 @@ src_vocab_size: 10000
 # Size of target word dictionay
 trg_vocab_size: 10000
 # Used to pad vocab size to be multiple of pad_factor.
-pad_factor: 8
+pad_factor: 1
 # Used to pad sequence length to be multiple of pad_seq.
 pad_seq: 1
 # Used to make batch size to be multiple of bsz_multi.
@@ -99,10 +100,6 @@ dropout: 0.1
 # The flag indicating whether to share embedding and softmax weights.
 # Vocabularies in source and target should be same for weight sharing.
 weight_sharing: True
-
-# Use amp or not
-use_amp: False
-scale_loss: 1.0
 
 # Whether to use multi-card/multi-node distributed training.
 # Only works for static graph for now.

--- a/PaddleNLP/benchmark/transformer/configs/transformer.big.yaml
+++ b/PaddleNLP/benchmark/transformer/configs/transformer.big.yaml
@@ -51,7 +51,7 @@ beta1: 0.9
 beta2: 0.997
 eps: 1e-9
 # The parameters for learning rate scheduling.
-warmup_steps: 4000
+warmup_steps: 16000
 # The weight used to mix up the ground-truth distribution and the fixed
 # uniform distribution in label smoothing when training.
 # Set this as zero if label smoothing is not wanted.

--- a/PaddleNLP/benchmark/transformer/configs/transformer.big.yaml
+++ b/PaddleNLP/benchmark/transformer/configs/transformer.big.yaml
@@ -7,7 +7,7 @@ init_from_checkpoint: ""
 # Path of the pretrain model, to better solve the current task
 init_from_pretrain_model: ""
 # Path of trained parameter, to make prediction
-init_from_params: "./trained_models/step_450000/"
+init_from_params: "./trained_models/step_final/"
 # The directory for saving model
 save_model: "trained_models"
 # Set seed for CE or debug
@@ -17,21 +17,16 @@ output_file: "predict.txt"
 # The <bos>, <eos> and <unk> tokens in the dictionary.
 special_token: ["<s>", "<e>", "<unk>"]
 # The directory to store data.
-root: "/workspace/models-1/PaddleNLP/benchmark/transformer/"
+root: None
 
 # Whether to use cuda
 use_gpu: True
 
-# Mixed precision training
-use_amp: True
-use_pure_fp16: True
-scale_loss: 128.0
-
 # Args for reader, see reader.py for details
 pool_size: 200000
 sort_type: "global"
-batch_size: 5120
-infer_batch_size: 8
+batch_size: 4096
+infer_batch_size: 16
 shuffle_batch: True
 # Data shuffle only works when sort_type is pool or none
 shuffle: True
@@ -51,7 +46,7 @@ beta1: 0.9
 beta2: 0.997
 eps: 1e-9
 # The parameters for learning rate scheduling.
-warmup_steps: 16000
+warmup_steps: 4000
 # The weight used to mix up the ground-truth distribution and the fixed
 # uniform distribution in label smoothing when training.
 # Set this as zero if label smoothing is not wanted.
@@ -72,7 +67,7 @@ src_vocab_size: 10000
 # Size of target word dictionay
 trg_vocab_size: 10000
 # Used to pad vocab size to be multiple of pad_factor.
-pad_factor: 1
+pad_factor: 8
 # Used to pad sequence length to be multiple of pad_seq.
 pad_seq: 1
 # Used to make batch size to be multiple of bsz_multi.
@@ -100,6 +95,11 @@ dropout: 0.1
 # The flag indicating whether to share embedding and softmax weights.
 # Vocabularies in source and target should be same for weight sharing.
 weight_sharing: True
+
+# Mixed precision training
+use_amp: False
+use_pure_fp16: False
+scale_loss: 128.0
 
 # Whether to use multi-card/multi-node distributed training.
 # Only works for static graph for now.

--- a/PaddleNLP/benchmark/transformer/configs/transformer.big.yaml
+++ b/PaddleNLP/benchmark/transformer/configs/transformer.big.yaml
@@ -22,6 +22,10 @@ root: None
 # Whether to use cuda
 use_gpu: True
 
+# Mixed precision training
+use_amp: True
+scale_loss: 128.0
+
 # Args for reader, see reader.py for details
 pool_size: 200000
 sort_type: "global"

--- a/PaddleNLP/benchmark/transformer/static/predict.py
+++ b/PaddleNLP/benchmark/transformer/static/predict.py
@@ -87,6 +87,11 @@ def do_predict(args):
     exe = paddle.static.Executor(place)
     exe.run(startup_program)
 
+    amp_list = paddle.static.amp.AutoMixedPrecisionLists(
+                custom_white_list=['softmax', 'layer_norm'],
+                custom_black_list=['tril_triu'])
+    paddle.static.amp.cast_model_to_fp16(test_program, amp_list)
+
     assert (
         args.init_from_params), "must set init_from_params to load parameters"
     paddle.static.load(test_program,

--- a/PaddleNLP/benchmark/transformer/static/train.py
+++ b/PaddleNLP/benchmark/transformer/static/train.py
@@ -96,16 +96,6 @@ def do_train(args):
             beta2=args.beta2,
             epsilon=float(args.eps),
             parameters=transformer.parameters())
-        if args.use_amp:
-            amp_list = paddle.static.amp.AutoMixedPrecisionLists(
-                custom_white_list=['softmax', 'layer_norm'],
-                custom_black_list=['tril_triu'])
-            optimizer = paddle.static.amp.decorate(
-                optimizer,
-                amp_list,
-                init_loss_scaling=args.scale_loss,
-                use_dynamic_loss_scaling=True,
-                use_pure_fp16=args.use_pure_fp16)
 
         if args.is_distributed:
             build_strategy = paddle.static.BuildStrategy()
@@ -124,6 +114,17 @@ def do_train(args):
 
             optimizer = fleet.distributed_optimizer(
                 optimizer, strategy=dist_strategy)
+        else:
+            if args.use_amp:
+                amp_list = paddle.static.amp.AutoMixedPrecisionLists(
+                    custom_white_list=['softmax', 'layer_norm'],
+                    custom_black_list=['lookup_table_v2'])
+                optimizer = paddle.static.amp.decorate(
+                    optimizer,
+                    amp_list,
+                    init_loss_scaling=args.scale_loss,
+                    use_dynamic_loss_scaling=True,
+                    use_pure_fp16=args.use_pure_fp16)
         optimizer.minimize(avg_cost)
 
     if args.is_distributed:
@@ -140,7 +141,7 @@ def do_train(args):
                 exec_strategy=exec_strategy)
     exe.run(startup_program)
 
-    if args.use_amp:
+    if not args.is_distributed and args.use_amp:
         optimizer.amp_init(places[0])
 
     # the best cross-entropy value with label smoothing

--- a/PaddleNLP/benchmark/transformer/static/train.py
+++ b/PaddleNLP/benchmark/transformer/static/train.py
@@ -58,7 +58,6 @@ def do_train(args):
 
     train_program = paddle.static.Program()
     startup_program = paddle.static.Program()
-    test_program = paddle.static.Program()
     with paddle.static.program_guard(train_program, startup_program):
         src_word = paddle.static.data(
             name="src_word", shape=[None, None], dtype="int64")
@@ -84,7 +83,7 @@ def do_train(args):
         criterion = CrossEntropyCriterion(args.label_smooth_eps, args.bos_idx)
 
         logits = transformer(src_word=src_word, trg_word=trg_word)
-        #with paddle.static.amp.fp16_guard():
+
         sum_cost, avg_cost, token_num = criterion(logits, lbl_word)
 
         scheduler = paddle.optimizer.lr.NoamDecay(

--- a/PaddleNLP/benchmark/transformer/static/train.py
+++ b/PaddleNLP/benchmark/transformer/static/train.py
@@ -96,6 +96,14 @@ def do_train(args):
             beta2=args.beta2,
             epsilon=float(args.eps),
             parameters=transformer.parameters())
+        if args.use_amp:
+            amp_list = paddle.static.amp.AutoMixedPrecisionLists(
+                custom_white_list=['layer_norm', 'softmax'])
+            optimizer = paddle.static.amp.decorate(
+                optimizer,
+                amp_list,
+                init_loss_scaling=args.scale_loss,
+                use_dynamic_loss_scaling=True)
 
         if args.is_distributed:
             build_strategy = paddle.static.BuildStrategy()

--- a/PaddleNLP/benchmark/transformer/static/train.py
+++ b/PaddleNLP/benchmark/transformer/static/train.py
@@ -83,7 +83,7 @@ def do_train(args):
         criterion = CrossEntropyCriterion(args.label_smooth_eps, args.bos_idx)
 
         logits = transformer(src_word=src_word, trg_word=trg_word)
-
+        #with paddle.static.amp.fp16_guard():
         sum_cost, avg_cost, token_num = criterion(logits, lbl_word)
 
         scheduler = paddle.optimizer.lr.NoamDecay(
@@ -98,12 +98,14 @@ def do_train(args):
             parameters=transformer.parameters())
         if args.use_amp:
             amp_list = paddle.static.amp.AutoMixedPrecisionLists(
-                custom_white_list=['layer_norm', 'softmax'])
+                custom_white_list=['softmax', 'layer_norm'],
+                custom_black_list=['tril_triu'])
             optimizer = paddle.static.amp.decorate(
                 optimizer,
                 amp_list,
                 init_loss_scaling=args.scale_loss,
-                use_dynamic_loss_scaling=True)
+                use_dynamic_loss_scaling=True,
+                use_pure_fp16=args.use_pure_fp16)
 
         if args.is_distributed:
             build_strategy = paddle.static.BuildStrategy()
@@ -137,6 +139,9 @@ def do_train(args):
                 build_strategy=build_strategy,
                 exec_strategy=exec_strategy)
     exe.run(startup_program)
+
+    if args.use_amp:
+        optimizer.amp_init(places[0])
 
     # the best cross-entropy value with label smoothing
     loss_normalizer = -(

--- a/PaddleNLP/benchmark/transformer/static/train.py
+++ b/PaddleNLP/benchmark/transformer/static/train.py
@@ -58,6 +58,7 @@ def do_train(args):
 
     train_program = paddle.static.Program()
     startup_program = paddle.static.Program()
+    test_program = paddle.static.Program()
     with paddle.static.program_guard(train_program, startup_program):
         src_word = paddle.static.data(
             name="src_word", shape=[None, None], dtype="int64")

--- a/PaddleNLP/paddlenlp/transformers/transformer/modeling.py
+++ b/PaddleNLP/paddlenlp/transformers/transformer/modeling.py
@@ -287,29 +287,29 @@ class TransformerModel(nn.Layer):
         trg_pos = paddle.cast(
             trg_word != self.bos_id, dtype="int64") * paddle.arange(
                 start=0, end=trg_max_len)
-        with paddle.static.amp.fp16_guard():
-            src_emb = self.src_word_embedding(src_word)
-            src_pos_emb = self.src_pos_embedding(src_pos)
-            src_emb = src_emb + src_pos_emb
-            enc_input = F.dropout(
-                src_emb, p=self.dropout,
-                training=self.training) if self.dropout else src_emb
+        #with paddle.static.amp.fp16_guard():
+        src_emb = self.src_word_embedding(src_word)
+        src_pos_emb = self.src_pos_embedding(src_pos)
+        src_emb = src_emb + src_pos_emb
+        enc_input = F.dropout(
+            src_emb, p=self.dropout,
+            training=self.training) if self.dropout else src_emb
 
-            trg_emb = self.trg_word_embedding(trg_word)
-            trg_pos_emb = self.trg_pos_embedding(trg_pos)
-            trg_emb = trg_emb + trg_pos_emb
-            dec_input = F.dropout(
-                trg_emb, p=self.dropout,
-                training=self.training) if self.dropout else trg_emb
+        trg_emb = self.trg_word_embedding(trg_word)
+        trg_pos_emb = self.trg_pos_embedding(trg_pos)
+        trg_emb = trg_emb + trg_pos_emb
+        dec_input = F.dropout(
+            trg_emb, p=self.dropout,
+            training=self.training) if self.dropout else trg_emb
 
-            dec_output = self.transformer(
-                enc_input,
-                dec_input,
-                src_mask=src_slf_attn_bias,
-                tgt_mask=trg_slf_attn_bias,
-                memory_mask=trg_src_attn_bias)
+        dec_output = self.transformer(
+            enc_input,
+            dec_input,
+            src_mask=src_slf_attn_bias,
+            tgt_mask=trg_slf_attn_bias,
+            memory_mask=trg_src_attn_bias)
 
-            predict = self.linear(dec_output)
+        predict = self.linear(dec_output)
 
         return predict
 

--- a/PaddleNLP/paddlenlp/transformers/transformer/modeling.py
+++ b/PaddleNLP/paddlenlp/transformers/transformer/modeling.py
@@ -287,29 +287,29 @@ class TransformerModel(nn.Layer):
         trg_pos = paddle.cast(
             trg_word != self.bos_id, dtype="int64") * paddle.arange(
                 start=0, end=trg_max_len)
-        #with paddle.static.amp.fp16_guard():
-        src_emb = self.src_word_embedding(src_word)
-        src_pos_emb = self.src_pos_embedding(src_pos)
-        src_emb = src_emb + src_pos_emb
-        enc_input = F.dropout(
-            src_emb, p=self.dropout,
-            training=self.training) if self.dropout else src_emb
+        with paddle.static.amp.fp16_guard():
+            src_emb = self.src_word_embedding(src_word)
+            src_pos_emb = self.src_pos_embedding(src_pos)
+            src_emb = src_emb + src_pos_emb
+            enc_input = F.dropout(
+                src_emb, p=self.dropout,
+                training=self.training) if self.dropout else src_emb
 
-        trg_emb = self.trg_word_embedding(trg_word)
-        trg_pos_emb = self.trg_pos_embedding(trg_pos)
-        trg_emb = trg_emb + trg_pos_emb
-        dec_input = F.dropout(
-            trg_emb, p=self.dropout,
-            training=self.training) if self.dropout else trg_emb
+            trg_emb = self.trg_word_embedding(trg_word)
+            trg_pos_emb = self.trg_pos_embedding(trg_pos)
+            trg_emb = trg_emb + trg_pos_emb
+            dec_input = F.dropout(
+                trg_emb, p=self.dropout,
+                training=self.training) if self.dropout else trg_emb
 
-        dec_output = self.transformer(
-            enc_input,
-            dec_input,
-            src_mask=src_slf_attn_bias,
-            tgt_mask=trg_slf_attn_bias,
-            memory_mask=trg_src_attn_bias)
+            dec_output = self.transformer(
+                enc_input,
+                dec_input,
+                src_mask=src_slf_attn_bias,
+                tgt_mask=trg_slf_attn_bias,
+                memory_mask=trg_src_attn_bias)
 
-        predict = self.linear(dec_output)
+            predict = self.linear(dec_output)
 
         return predict
 
@@ -355,28 +355,29 @@ class InferTransformerModel(TransformerModel):
                 start=0, end=src_max_len)
 
         # Run encoder
-        src_emb = self.src_word_embedding(src_word)
-        src_pos_emb = self.src_pos_embedding(src_pos)
-        src_emb = src_emb + src_pos_emb
-        enc_input = F.dropout(
-            src_emb, p=self.dropout,
-            training=False) if self.dropout else src_emb
-        enc_output = self.transformer.encoder(enc_input, src_slf_attn_bias)
+        with paddle.static.amp.fp16_guard():
+            src_emb = self.src_word_embedding(src_word)
+            src_pos_emb = self.src_pos_embedding(src_pos)
+            src_emb = src_emb + src_pos_emb
+            enc_input = F.dropout(
+                src_emb, p=self.dropout,
+                training=False) if self.dropout else src_emb
+            enc_output = self.transformer.encoder(enc_input, src_slf_attn_bias)
 
-        # Init states (caches) for transformer, need to be updated according to selected beam
-        incremental_cache, static_cache = self.transformer.decoder.gen_cache(
-            enc_output, do_zip=True)
+            # Init states (caches) for transformer, need to be updated according to selected beam
+            incremental_cache, static_cache = self.transformer.decoder.gen_cache(
+                enc_output, do_zip=True)
 
-        static_cache, enc_output, trg_src_attn_bias = TransformerBeamSearchDecoder.tile_beam_merge_with_batch(
-            (static_cache, enc_output, trg_src_attn_bias), self.beam_size)
+            static_cache, enc_output, trg_src_attn_bias = TransformerBeamSearchDecoder.tile_beam_merge_with_batch(
+                (static_cache, enc_output, trg_src_attn_bias), self.beam_size)
 
-        rs, _ = nn.decode.dynamic_decode(
-            decoder=self.decode,
-            inits=incremental_cache,
-            max_step_num=self.max_out_len,
-            memory=enc_output,
-            trg_src_attn_bias=trg_src_attn_bias,
-            static_cache=static_cache,
-            is_test=True)
+            rs, _ = nn.decode.dynamic_decode(
+                decoder=self.decode,
+                inits=incremental_cache,
+                max_step_num=self.max_out_len,
+                memory=enc_output,
+                trg_src_attn_bias=trg_src_attn_bias,
+                static_cache=static_cache,
+                is_test=True)
 
         return rs

--- a/PaddleNLP/paddlenlp/transformers/transformer/modeling.py
+++ b/PaddleNLP/paddlenlp/transformers/transformer/modeling.py
@@ -287,29 +287,29 @@ class TransformerModel(nn.Layer):
         trg_pos = paddle.cast(
             trg_word != self.bos_id, dtype="int64") * paddle.arange(
                 start=0, end=trg_max_len)
+        with paddle.static.amp.fp16_guard():
+            src_emb = self.src_word_embedding(src_word)
+            src_pos_emb = self.src_pos_embedding(src_pos)
+            src_emb = src_emb + src_pos_emb
+            enc_input = F.dropout(
+                src_emb, p=self.dropout,
+                training=self.training) if self.dropout else src_emb
 
-        src_emb = self.src_word_embedding(src_word)
-        src_pos_emb = self.src_pos_embedding(src_pos)
-        src_emb = src_emb + src_pos_emb
-        enc_input = F.dropout(
-            src_emb, p=self.dropout,
-            training=self.training) if self.dropout else src_emb
+            trg_emb = self.trg_word_embedding(trg_word)
+            trg_pos_emb = self.trg_pos_embedding(trg_pos)
+            trg_emb = trg_emb + trg_pos_emb
+            dec_input = F.dropout(
+                trg_emb, p=self.dropout,
+                training=self.training) if self.dropout else trg_emb
 
-        trg_emb = self.trg_word_embedding(trg_word)
-        trg_pos_emb = self.trg_pos_embedding(trg_pos)
-        trg_emb = trg_emb + trg_pos_emb
-        dec_input = F.dropout(
-            trg_emb, p=self.dropout,
-            training=self.training) if self.dropout else trg_emb
+            dec_output = self.transformer(
+                enc_input,
+                dec_input,
+                src_mask=src_slf_attn_bias,
+                tgt_mask=trg_slf_attn_bias,
+                memory_mask=trg_src_attn_bias)
 
-        dec_output = self.transformer(
-            enc_input,
-            dec_input,
-            src_mask=src_slf_attn_bias,
-            tgt_mask=trg_slf_attn_bias,
-            memory_mask=trg_src_attn_bias)
-
-        predict = self.linear(dec_output)
+            predict = self.linear(dec_output)
 
         return predict
 

--- a/PaddleNLP/paddlenlp/transformers/transformer/modeling.py
+++ b/PaddleNLP/paddlenlp/transformers/transformer/modeling.py
@@ -294,21 +294,21 @@ class TransformerModel(nn.Layer):
             enc_input = F.dropout(
                 src_emb, p=self.dropout,
                 training=self.training) if self.dropout else src_emb
-
+            
             trg_emb = self.trg_word_embedding(trg_word)
             trg_pos_emb = self.trg_pos_embedding(trg_pos)
             trg_emb = trg_emb + trg_pos_emb
             dec_input = F.dropout(
                 trg_emb, p=self.dropout,
                 training=self.training) if self.dropout else trg_emb
-
+            
             dec_output = self.transformer(
                 enc_input,
                 dec_input,
                 src_mask=src_slf_attn_bias,
                 tgt_mask=trg_slf_attn_bias,
                 memory_mask=trg_src_attn_bias)
-
+            
             predict = self.linear(dec_output)
 
         return predict
@@ -355,29 +355,28 @@ class InferTransformerModel(TransformerModel):
                 start=0, end=src_max_len)
 
         # Run encoder
-        with paddle.static.amp.fp16_guard():
-            src_emb = self.src_word_embedding(src_word)
-            src_pos_emb = self.src_pos_embedding(src_pos)
-            src_emb = src_emb + src_pos_emb
-            enc_input = F.dropout(
-                src_emb, p=self.dropout,
-                training=False) if self.dropout else src_emb
-            enc_output = self.transformer.encoder(enc_input, src_slf_attn_bias)
+        src_emb = self.src_word_embedding(src_word)
+        src_pos_emb = self.src_pos_embedding(src_pos)
+        src_emb = src_emb + src_pos_emb
+        enc_input = F.dropout(
+            src_emb, p=self.dropout,
+            training=False) if self.dropout else src_emb
+        enc_output = self.transformer.encoder(enc_input, src_slf_attn_bias)
 
-            # Init states (caches) for transformer, need to be updated according to selected beam
-            incremental_cache, static_cache = self.transformer.decoder.gen_cache(
-                enc_output, do_zip=True)
+        # Init states (caches) for transformer, need to be updated according to selected beam
+        incremental_cache, static_cache = self.transformer.decoder.gen_cache(
+            enc_output, do_zip=True)
 
-            static_cache, enc_output, trg_src_attn_bias = TransformerBeamSearchDecoder.tile_beam_merge_with_batch(
-                (static_cache, enc_output, trg_src_attn_bias), self.beam_size)
+        static_cache, enc_output, trg_src_attn_bias = TransformerBeamSearchDecoder.tile_beam_merge_with_batch(
+            (static_cache, enc_output, trg_src_attn_bias), self.beam_size)
 
-            rs, _ = nn.decode.dynamic_decode(
-                decoder=self.decode,
-                inits=incremental_cache,
-                max_step_num=self.max_out_len,
-                memory=enc_output,
-                trg_src_attn_bias=trg_src_attn_bias,
-                static_cache=static_cache,
-                is_test=True)
+        rs, _ = nn.decode.dynamic_decode(
+            decoder=self.decode,
+            inits=incremental_cache,
+            max_step_num=self.max_out_len,
+            memory=enc_output,
+            trg_src_attn_bias=trg_src_attn_bias,
+            static_cache=static_cache,
+            is_test=True)
 
         return rs


### PR DESCRIPTION
support AMP training

使用混合精度训练，通过设置：
- use_amp=True，开启AMP训练，默认是O1 level
- 如果希望开启AMP训练，同时优化级别为O2，需要设置：use_amp=True，use_pure_fp16=True

模型评估时，需要注意：
- 如果use_pure_fp16=False，即O1 level的训练，权重是fp32的，因此可以直接加载进行predict
-  如果use_pure_fp16=True，即O2 level的训练，权重是fp16的，需要cast为fp32进行predict，已在predict.py中添加此功能

其他说明：
- 为了支持O2 level的训练，model部分使用了`fp16_guard`，已测试不影响fp32训练，也不影响动态图。