### PR TITLE
Fix delimiter

### DIFF
--- a/PaddleNLP/paddlenlp/datasets/translation.py
+++ b/PaddleNLP/paddlenlp/datasets/translation.py
@@ -31,7 +31,7 @@ def get_default_tokenizer():
 
     def _split_tokenizer(x, delimiter=None):
         if delimiter == "":
-            return x
+            return list(x)
         return x.split(delimiter)
 
     return _split_tokenizer

--- a/PaddleNLP/paddlenlp/datasets/translation.py
+++ b/PaddleNLP/paddlenlp/datasets/translation.py
@@ -30,6 +30,8 @@ def get_default_tokenizer():
     """
 
     def _split_tokenizer(x, delimiter=None):
+        if delimiter == "":
+            return x
         return x.split(delimiter)
 
     return _split_tokenizer


### PR DESCRIPTION
When using `str.split()`, `str` cannot be split by `""`. 