### PR TITLE
[Perform] Apply pad factor to pad vocab

### DIFF
--- a/PaddleNLP/benchmark/transformer/configs/transformer.big.yaml
+++ b/PaddleNLP/benchmark/transformer/configs/transformer.big.yaml
@@ -66,6 +66,8 @@ n_best: 1
 src_vocab_size: 10000
 # Size of target word dictionay
 trg_vocab_size: 10000
+# Used to pad vocab size to be multiple of pad_factor.
+pad_factor: 8
 # Index for <bos> token
 bos_idx: 0
 # Index for <eos> token

--- a/PaddleNLP/benchmark/transformer/reader.py
+++ b/PaddleNLP/benchmark/transformer/reader.py
@@ -36,7 +36,11 @@ def min_max_filer(data, max_len, min_len=0):
 def create_data_loader(args):
     root = None if args.root == "None" else args.root
     (src_vocab, trg_vocab) = WMT14ende.get_vocab(root=root)
-    args.src_vocab_size, args.trg_vocab_size = len(src_vocab), len(trg_vocab)
+    padding_vocab = (
+        lambda x: (x + args.pad_factor - 1) // args.pad_factor * args.pad_factor
+    )
+    args.src_vocab_size = padding_vocab(len(src_vocab))
+    args.trg_vocab_size = padding_vocab(len(trg_vocab))
     transform_func = WMT14ende.get_default_transform_func(root=root)
     datasets = [
         WMT14ende.get_datasets(
@@ -107,7 +111,11 @@ def create_data_loader(args):
 def create_infer_loader(args):
     root = None if args.root == "None" else args.root
     (src_vocab, trg_vocab) = WMT14ende.get_vocab(root=root)
-    args.src_vocab_size, args.trg_vocab_size = len(src_vocab), len(trg_vocab)
+    padding_vocab = (
+        lambda x: (x + args.pad_factor - 1) // args.pad_factor * args.pad_factor
+    )
+    args.src_vocab_size = padding_vocab(len(src_vocab))
+    args.trg_vocab_size = padding_vocab(len(trg_vocab))
     transform_func = WMT14ende.get_default_transform_func(root=root)
     dataset = WMT14ende.get_datasets(
         mode="test", transform_func=transform_func).filter(

--- a/PaddleNLP/examples/machine_translation/transformer/configs/transformer.base.yaml
+++ b/PaddleNLP/examples/machine_translation/transformer/configs/transformer.base.yaml
@@ -66,6 +66,8 @@ n_best: 1
 src_vocab_size: 10000
 # Size of target word dictionay
 trg_vocab_size: 10000
+# Used to pad vocab size to be multiple of pad_factor.
+pad_factor: 8
 # Index for <bos> token
 bos_idx: 0
 # Index for <eos> token

--- a/PaddleNLP/examples/machine_translation/transformer/configs/transformer.big.yaml
+++ b/PaddleNLP/examples/machine_translation/transformer/configs/transformer.big.yaml
@@ -66,6 +66,8 @@ n_best: 1
 src_vocab_size: 10000
 # Size of target word dictionay
 trg_vocab_size: 10000
+# Used to pad vocab size to be multiple of pad_factor.
+pad_factor: 8
 # Index for <bos> token
 bos_idx: 0
 # Index for <eos> token

--- a/PaddleNLP/examples/machine_translation/transformer/reader.py
+++ b/PaddleNLP/examples/machine_translation/transformer/reader.py
@@ -36,7 +36,11 @@ def min_max_filer(data, max_len, min_len=0):
 def create_data_loader(args):
     root = None if args.root == "None" else args.root
     (src_vocab, trg_vocab) = WMT14ende.get_vocab(root=root)
-    args.src_vocab_size, args.trg_vocab_size = len(src_vocab), len(trg_vocab)
+    padding_vocab = (
+        lambda x: (x + args.pad_factor - 1) // args.pad_factor * args.pad_factor
+    )
+    args.src_vocab_size = padding_vocab(len(src_vocab))
+    args.trg_vocab_size = padding_vocab(len(trg_vocab))
     transform_func = WMT14ende.get_default_transform_func(root=root)
     datasets = [
         WMT14ende.get_datasets(
@@ -107,7 +111,11 @@ def create_data_loader(args):
 def create_infer_loader(args):
     root = None if args.root == "None" else args.root
     (src_vocab, trg_vocab) = WMT14ende.get_vocab(root=root)
-    args.src_vocab_size, args.trg_vocab_size = len(src_vocab), len(trg_vocab)
+    padding_vocab = (
+        lambda x: (x + args.pad_factor - 1) // args.pad_factor * args.pad_factor
+    )
+    args.src_vocab_size = padding_vocab(len(src_vocab))
+    args.trg_vocab_size = padding_vocab(len(trg_vocab))
     transform_func = WMT14ende.get_default_transform_func(root=root)
     dataset = WMT14ende.get_datasets(
         mode="test", transform_func=transform_func).filter(

--- a/PaddleNLP/examples/machine_translation/transformer/train.py
+++ b/PaddleNLP/examples/machine_translation/transformer/train.py
@@ -46,8 +46,6 @@ def do_train(args):
     (train_loader), (eval_loader) = reader.create_data_loader(args)
 
     # Define model
-    print(args.src_vocab_size)
-    print(args.trg_vocab_size)
     transformer = TransformerModel(
         src_vocab_size=args.src_vocab_size,
         trg_vocab_size=args.trg_vocab_size,

--- a/PaddleNLP/examples/machine_translation/transformer/train.py
+++ b/PaddleNLP/examples/machine_translation/transformer/train.py
@@ -46,6 +46,8 @@ def do_train(args):
     (train_loader), (eval_loader) = reader.create_data_loader(args)
 
     # Define model
+    print(args.src_vocab_size)
+    print(args.trg_vocab_size)
     transformer = TransformerModel(
         src_vocab_size=args.src_vocab_size,
         trg_vocab_size=args.trg_vocab_size,


### PR DESCRIPTION
Apply `pad_factor` to ensure the size of vocab is multiple of the factor which can be used for Tensor Core acceleration. 
According to zhangting, the performance of `matmul` forward can be upgraded from 14ms to 10ms. 