### PR TITLE
set stop_gradient

### DIFF
--- a/PaddleNLP/paddlenlp/transformers/transformer/modeling.py
+++ b/PaddleNLP/paddlenlp/transformers/transformer/modeling.py
@@ -276,8 +276,10 @@ class TransformerModel(nn.Layer):
         src_slf_attn_bias = paddle.cast(
             src_word == self.bos_id,
             dtype=paddle.get_default_dtype()).unsqueeze([1, 2]) * -1e9
+        src_slf_attn_bias.stop_gradient = True
         trg_slf_attn_bias = self.transformer.generate_square_subsequent_mask(
             trg_max_len)
+        trg_slf_attn_bias.stop_gradient = True
         trg_src_attn_bias = src_slf_attn_bias
         src_pos = paddle.cast(
             src_word != self.bos_id, dtype="int64") * paddle.arange(


### PR DESCRIPTION
由于个别tensor不需要计算梯度，设置stop_gradient，避免梯度计算。模型性能提升2.8%。
以下：
- src_slf_attn_bias涉及到elementwise_add，
- trg_slf_attn_bias涉及到tril_triu op

