### PR TITLE
fix crf bug

### DIFF
--- a/PaddleNLP/examples/lexical_analysis/data.py
+++ b/PaddleNLP/examples/lexical_analysis/data.py
@@ -161,11 +161,11 @@ def parse_lac_result(words, preds, lengths, word_vocab, label_vocab):
     for sent_index in range(len(lengths)):
         sent = [
             id2word_dict[index]
-            for index in words[sent_index][:lengths[sent_index] - 1]
+            for index in words[sent_index][:lengths[sent_index]]
         ]
         tags = [
             id2label_dict[index]
-            for index in preds[sent_index][:lengths[sent_index] - 1]
+            for index in preds[sent_index][:lengths[sent_index]]
         ]
 
         sent_out = []

--- a/PaddleNLP/examples/lexical_analysis/eval.py
+++ b/PaddleNLP/examples/lexical_analysis/eval.py
@@ -56,7 +56,7 @@ def evaluate(args):
         dataset=test_dataset,
         batch_size=args.batch_size,
         shuffle=False,
-        drop_last=True)
+        drop_last=False)
     test_loader = paddle.io.DataLoader(
         dataset=test_dataset,
         batch_sampler=test_sampler,

--- a/PaddleNLP/examples/lexical_analysis/model.py
+++ b/PaddleNLP/examples/lexical_analysis/model.py
@@ -74,8 +74,8 @@ class BiGruCrf(nn.Layer):
 
         self.fc = nn.Linear(
             in_features=self.hidden_size * 2,
-            out_features=self.num_labels + 2
-            if with_start_stop_tag else self.num_labels,
+            out_features=self.num_labels + 2 \
+                if with_start_stop_tag else self.num_labels,
             weight_attr=paddle.ParamAttr(
                 initializer=nn.initializer.Uniform(
                     low=-self.init_bound, high=self.init_bound),

--- a/PaddleNLP/examples/lexical_analysis/predict.py
+++ b/PaddleNLP/examples/lexical_analysis/predict.py
@@ -55,7 +55,7 @@ def infer(args):
         dataset=infer_dataset,
         batch_size=args.batch_size,
         shuffle=False,
-        drop_last=True)
+        drop_last=False)
     infer_loader = paddle.io.DataLoader(
         dataset=infer_dataset,
         batch_sampler=infer_sampler,
@@ -75,7 +75,7 @@ def infer(args):
         test_data=infer_loader, batch_size=args.batch_size)
 
     # Post-processing the lexical analysis results
-    lengths = np.array(lengths).reshape([-1])
+    lengths = np.array([l for lens in lengths for l in lens]).reshape([-1])
     preds = np.array(
         [pred for batch_pred in crf_decodes for pred in batch_pred])
 

--- a/PaddleNLP/examples/lexical_analysis/train.py
+++ b/PaddleNLP/examples/lexical_analysis/train.py
@@ -77,7 +77,7 @@ def train(args):
         dataset=test_dataset,
         batch_size=args.batch_size,
         shuffle=False,
-        drop_last=True)
+        drop_last=False)
     test_loader = paddle.io.DataLoader(
         dataset=test_dataset,
         batch_sampler=test_sampler,
@@ -109,7 +109,6 @@ def train(args):
               log_freq=10,
               save_dir=args.model_save_dir,
               save_freq=1,
-              drop_last=True,
               shuffle=True)
 
 

--- a/PaddleNLP/examples/lexical_analysis/train.py
+++ b/PaddleNLP/examples/lexical_analysis/train.py
@@ -93,7 +93,7 @@ def train(args):
     # Prepare optimizer, loss and metric evaluator
     optimizer = paddle.optimizer.Adam(
         learning_rate=args.base_lr, parameters=model.parameters())
-    crf_loss = LinearChainCrfLoss(network.crf.transitions)
+    crf_loss = LinearChainCrfLoss(network.crf)
     chunk_evaluator = ChunkEvaluator(
         label_list=train_dataset.label_vocab.keys(), suffix=True)
     model.prepare(optimizer, crf_loss, chunk_evaluator)
@@ -101,7 +101,6 @@ def train(args):
         model.load(args.init_checkpoint)
 
     # Start training
-    callback = paddle.callbacks.ProgBarLogger(log_freq=10, verbose=3)
     model.fit(train_data=train_loader,
               eval_data=test_loader,
               batch_size=args.batch_size,
@@ -111,8 +110,7 @@ def train(args):
               save_dir=args.model_save_dir,
               save_freq=1,
               drop_last=True,
-              shuffle=True,
-              callbacks=callback)
+              shuffle=True)
 
 
 if __name__ == "__main__":

--- a/PaddleNLP/examples/named_entity_recognition/express_ner/run_bigru_crf.py
+++ b/PaddleNLP/examples/named_entity_recognition/express_ner/run_bigru_crf.py
@@ -164,7 +164,7 @@ if __name__ == '__main__':
 
     optimizer = paddle.optimizer.Adam(
         learning_rate=0.001, parameters=model.parameters())
-    crf_loss = LinearChainCrfLoss(network.crf.transitions)
+    crf_loss = LinearChainCrfLoss(network.crf)
     chunk_evaluator = ChunkEvaluator(
         label_list=train_ds.label_vocab.keys(), suffix=True)
     model.prepare(optimizer, crf_loss, chunk_evaluator)

--- a/PaddleNLP/paddlenlp/layers/crf.py
+++ b/PaddleNLP/paddlenlp/layers/crf.py
@@ -159,7 +159,6 @@ class LinearChainCrf(nn.Layer):
             sequence_mask(
                 self._get_batch_seq_index(batch_size, seq_len), lengths),
             'float32')
-        # if self.with_start_stop_tag:
         mask = mask[:, :seq_len]
 
         mask_scores = scores * mask
@@ -335,14 +334,10 @@ class ViterbiDecoder(nn.Layer):
             # We don't include the emission scores here because the max does not depend on them (we add them in below)
             alpha_max = alpha_trn_sum.max(2)
             if i == 0:
-                if self.with_start_stop_tag:
-                    # the first antecedent tag must be START
-                    pass
-                else:
-                    # the first label has not antecedent tag
-                    pass
+                # if self.with_start_stop_tag, the first antecedent tag must be START, drop it.
+                # else, the first label has not antecedent tag, pass it.
+                pass
             else:
-                # alpha_argmax is variational, we record in historys
                 alpha_argmax = alpha_trn_sum.argmax(2)
                 historys.append(alpha_argmax)
             # Now add the emission scores

--- a/PaddleNLP/paddlenlp/metrics/chunk.py
+++ b/PaddleNLP/paddlenlp/metrics/chunk.py
@@ -112,12 +112,12 @@ class ChunkEvaluator(paddle.metric.Metric):
             float: mean precision, recall and f1 score.
         """
         precision = float(
-            self.num_correct_chunks
-        ) / self.num_infer_chunks if self.num_infer_chunks else 0
-        recall = float(self.num_correct_chunks
-                       ) / self.num_label_chunks if self.num_label_chunks else 0
-        f1_score = float(2 * precision * recall) / (
-            precision + recall) if self.num_correct_chunks else 0
+            self.num_correct_chunks /
+            self.num_infer_chunks) if self.num_infer_chunks else 0.
+        recall = float(self.num_correct_chunks /
+                       self.num_label_chunks) if self.num_label_chunks else 0.
+        f1_score = float(2 * precision * recall / (
+            precision + recall)) if self.num_correct_chunks else 0.
         return precision, recall, f1_score
 
     def reset(self):


### PR DESCRIPTION
1. model.py支持参数with_start_stop_tag
2. LinearChainCrfLoss原来是传入转移矩阵就好了，它根据转移矩阵新建一个LinearChainCrf，这个新建操作是没有必要的，因此这里改成了接收LinearChainCrf
3. 补充了维特比解码对with_start_stop_tag=False的支持
已验证with_start_stop_tag=True和False都能跑通
4. 修复了CRF不支持drop_last=False的bug
5. 修复chunk accumulate中的类型问题