### PR TITLE
Fix url to download raw code

### DIFF
--- a/modelcenter/ERNIE-M/introduction_cn.ipynb
+++ b/modelcenter/ERNIE-M/introduction_cn.ipynb
@@ -44,7 +44,7 @@
     "\n",
     "```shell\n",
     "# 下载脚本文件（从gitee上更快）\n",
-    "wget https://gitee.com/paddlepaddle/PaddleNLP/blob/develop/model_zoo/ernie-m/run_classifier.py\n",
+    "wget https://gitee.com/paddlepaddle/PaddleNLP/raw/develop/model_zoo/ernie-m/run_classifier.py\n",
     "```\n",
     "\n",
     "* 单卡训练\n",
@@ -137,7 +137,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.7.13 ('model_center')",
+   "display_name": "Python 3.10.8 ('base')",
    "language": "python",
    "name": "python3"
   },
@@ -151,12 +151,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.13"
+   "version": "3.10.8"
   },
   "orig_nbformat": 4,
   "vscode": {
    "interpreter": {
-    "hash": "de1ffcbce2b3061b5001e2c22f3a27594f323d4a49b789ebdbef6534581834bd"
+    "hash": "2f394aca7ca06fed1e6064aef884364492d7cdda3614a461e02e6407fc40ba69"
    }
   }
  },

--- a/modelcenter/ERNIE-M/introduction_en.ipynb
+++ b/modelcenter/ERNIE-M/introduction_en.ipynb
@@ -43,7 +43,7 @@
     "\n",
     "```shell\n",
     "# download from gitee\n",
-    "wget https://gitee.com/paddlepaddle/PaddleNLP/blob/develop/model_zoo/ernie-m/run_classifier.py\n",
+    "wget https://gitee.com/paddlepaddle/PaddleNLP/raw/develop/model_zoo/ernie-m/run_classifier.py\n",
     "```\n",
     "\n",
     "* training with single gpu\n",


### PR DESCRIPTION
Replacing the error URL, and using `wget` to download raw code correctly.